### PR TITLE
Infinite loop in the python picklecache _invalidate() method

### DIFF
--- a/persistent/picklecache.py
+++ b/persistent/picklecache.py
@@ -122,7 +122,7 @@ class PickleCache(object):
             # splice into new
             self.ring.prev.next, node.prev = node, self.ring.prev
             self.ring.prev, node.next = node, self.ring
-        
+
     def ringlen(self):
         """ See IPickleCache.
         """
@@ -257,5 +257,6 @@ class PickleCache(object):
                 if node.object is value:
                     node.prev.next, node.next.prev = node.next, node.prev
                     break
+                node = node.next
         elif oid in self.persistent_classes:
             del self.persistent_classes[oid]

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -661,6 +661,25 @@ class PickleCacheTests(unittest.TestCase):
         self.assertEqual(c1._p_state, GHOST)
         self.assertEqual(c2._p_state, GHOST)
 
+    def test_invalidate_hit_multiple_non_ghost(self):
+        from persistent.interfaces import UPTODATE
+        from persistent.interfaces import GHOST
+        from persistent._compat import _b
+        KEY = _b('123')
+        KEY2 = _b('456')
+        cache = self._makeOne()
+        c1 = self._makePersist(oid=KEY, jar=cache.jar, state=UPTODATE)
+        cache[KEY] = c1
+        c2 = self._makePersist(oid=KEY2, jar=cache.jar, state=UPTODATE)
+        cache[KEY2] = c2
+        self.assertEqual(cache.ringlen(), 2)
+        # These should be in the opposite order of how they were
+        # added to the ring to ensure ring traversal works
+        cache.invalidate([KEY2, KEY])
+        self.assertEqual(cache.ringlen(), 0)
+        self.assertEqual(c1._p_state, GHOST)
+        self.assertEqual(c2._p_state, GHOST)
+
     def test_invalidate_hit_pclass(self):
         from persistent._compat import _b
         KEY = _b('123')


### PR DESCRIPTION
While testing changes to make `zope.container` work with PyPy, I noticed that the `zope.container` tests would hang forever when aborting a transaction. It turns out that the picklecache `_invalidate` method failed to properly traverse the ring if objects were invalidated in a different order than the ring. This commit fixes that and adds a test for that scenario.
