### PR TITLE
The pure-python Persistent class raises KeyError during ZODB serialization

### DIFF
--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -390,8 +390,16 @@ class Persistent(object):
         # detail, the '_cache' attribute of the jar.  We made it a
         # private API to avoid the cycle of keeping a reference to
         # the cache on the persistent object.
-        if self.__jar is not None and self.__oid is not None:
-            self.__jar._cache.mru(self.__oid)
+        if self.__jar is not None and self.__oid is not None and self._p_state >= 0:
+            # This scenario arises in ZODB: ZODB.serialize.ObjectWriter
+            # can assign a jar and an oid to newly seen persistent objects,
+            # but because they are newly created, they aren't in the
+            # pickle cache yet. There doesn't seem to be a way to distinguish
+            # that at this level, all we can do is catch it
+            try:
+                self.__jar._cache.mru(self.__oid)
+            except KeyError:
+                pass
 
 
 def _estimated_size_in_24_bits(value):

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1319,7 +1319,29 @@ class PyPersistentTests(unittest.TestCase, _Persistent_Base):
 
     def _clearMRU(self, jar):
         jar._cache._mru[:] = []
- 
+
+    def test_accessed_with_jar_and_oid_but_not_in_cache(self):
+        # This scenario arises in ZODB: ZODB.serialize.ObjectWriter
+        # can assign a jar and an oid to newly seen persistent objects,
+        # but because they are newly created, they aren't in the
+        # pickle cache yet.
+        # Nothing should blow up when this happens
+        from persistent._compat import _b
+        KEY = _b('123')
+        jar = self._makeJar()
+        c1 = self._makeOne()
+        c1._p_oid = KEY
+        c1._p_jar = jar
+        orig_mru = jar._cache.mru
+        def mru(oid):
+            # Mimic what the real cache does
+            if oid not in jar._cache._mru:
+                raise KeyError(oid)
+            orig_mru(oid)
+        jar._cache.mru = mru
+        c1._p_accessed()
+        self._checkMRU(jar, [])
+
 _add_to_suite = [PyPersistentTests]
 
 if not os.environ.get('PURE_PYTHON'):
@@ -1336,7 +1358,7 @@ if not os.environ.get('PURE_PYTHON'):
 
             def _checkMRU(self, jar, value):
                 pass # Figure this out later
-        
+
             def _clearMRU(self, jar):
                 pass # Figure this out later
 


### PR DESCRIPTION
While working to make `zope.container` work with PyPy, I noticed that `persistent.persistence.Persistent._p_accessed` raises `KeyError` when ZODB transactions are written, which naturally aborts the transaction::

```
  File "zope.container/eggs/ZODB-4.0.0-py2.7.egg/ZODB/Connection.py", line 660, in _store_objects
    p = writer.serialize(obj)  # This calls __getstate__ of obj
  File "zope.container/eggs/ZODB-4.0.0-py2.7.egg/ZODB/serialize.py", line 423, in serialize
    meta = klass, newargs()
  File "zope.container/src/zope/container/_proxy.py", line 89, in __getnewargs__
    return self._wrapped,
  File "zope.container/src/zope/container/_proxy.py", line 143, in __getattribute__
    return super(PyProxyBase, self).__getattribute__(name)
  File "zope.container/eggs/persistent-4.0.6-py2.7.egg/persistent/persistence.py", line 221, in __getattribute__
    _OGA(self, '_p_accessed')()
  File "zope.container/eggs/persistent-4.0.6-py2.7.egg/persistent/persistence.py", line 394, in _p_accessed
    self.__jar._cache.mru(self.__oid)
  File "zope.container/eggs/persistent-4.0.6-py2.7.egg/persistent/picklecache.py", line 113, in mru
    value = self.data[oid]
  File "pypy/lib-python/2.7/weakref.py", line 63, in __getitem__
    o = self.data[key]()
KeyError: ';\x8eh\xdcq\xfd\\\xa7'
```

As near as I can tell, what's happening is that this object is a newly reachable persistent object, so `ZODB.serialize.ObjectWriter:persistent_id` assigns it a jar and an OID. But that doesn't do anything about putting it in the pickle cache. When the object tries to execute `__getstate__`, invariably accessing attributes that aren't "special" (_p_) it notices that it has a jar and OID and tries to tell the pickle cache that it has been accessed, but because it's not actually in the cache yet, that fails.

This commit catches the error. There may be a better way, or this may be a symptom of a deeper problem, but that seems to work enough for `zope.container` anyway. 
