### PR TITLE
The pure-python Persistent class needs to support `del _p_jar`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``persistent`` Changelog
 ========================
 
+4.0.8 (Unreleased)
+------------------
+
+- Make it possible to delete the ``_p_jar`` of a pure-Python
+  ``Persistent`` object (fixes aborting a ZODB Connection that
+  has added objects).
 
 4.0.7 (2014-02-20)
 ------------------

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -72,7 +72,16 @@ class Persistent(object):
             self.__jar = value
             self.__flags = 0
 
-    _p_jar = property(_get_jar, _set_jar)
+    def _del_jar(self):
+        jar = self.__jar
+        oid = self.__oid
+        if jar is not None:
+            if oid and jar._cache.get(oid):
+                raise ValueError("can't delete _p_jar of cached object")
+            self.__setattr__('_Persistent__jar', None)
+            self.__flags = None
+
+    _p_jar = property(_get_jar, _set_jar, _del_jar)
 
     # _p_oid:  see IPersistent.
     def _get_oid(self):


### PR DESCRIPTION
When aborting a transaction that has added objects, ZODB tries to clean up the picklecache and remove the jar and oid of objects it has added. Before this commit, that failed:

```
txn.GLOBAL: ERROR: Failed to abort resource manager: <Connection at 1069b2b50>
Traceback (most recent call last):
  File "/transaction-1.4.1-py2.7.egg/transaction/_transaction.py", line 453, in abort
    rm.abort(self)
  File "/ZODB-4.0.0-py2.7.egg/ZODB/Connection.py", line 438, in abort
    self._abort()
  File "/ZODB-4.0.0-py2.7.egg/ZODB/Connection.py", line 456, in _abort
    del obj._p_jar
  File "/persistent-4.0.7-py2.7.egg/persistent/persistence.py", line 258, in __delattr__
    object.__delattr__(self, name)
AttributeError: can't delete attribute 
```

This commit makes it work like the C version.
