### PR TITLE
__setattr__ in subclasses of pure-Python Persistent can throw AttributeError in cases the C version does not

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 4.0.8 (Unreleased)
 ------------------
 
+- The pure-Python ``Persistent`` class no longer calls subclass's
+  ``__setattr__`` at instance creation time. (PR #8)
+
 - Make it possible to delete ``_p_jar`` / ``_p_oid`` of a pure-Python
   ``Persistent`` object which has been removed from the jar's cache
   (fixes aborting a ZODB Connection that has added objects). (PR #7)

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -53,11 +53,15 @@ class Persistent(object):
 
     def __new__(cls, *args, **kw):
         inst = super(Persistent, cls).__new__(cls)
-        inst.__jar = None
-        inst.__oid = None
-        inst.__serial = None
-        inst.__flags = None
-        inst.__size = 0
+        # We bypass the __setattr__ implementation of this object
+        # at __new__ time, just like the C implementation does. This
+        # makes us compatible with subclasses that want to access
+        # properties like _p_changed in their setattr implementation
+        _OSA(inst, '_Persistent__jar', None)
+        _OSA(inst, '_Persistent__oid', None)
+        _OSA(inst, '_Persistent__serial', None)
+        _OSA(inst, '_Persistent__flags', None)
+        _OSA(inst, '_Persistent__size', 0)
         return inst
 
     # _p_jar:  see IPersistent.

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1325,6 +1325,14 @@ class _Persistent_Base(object):
         class mixed2(self._getTargetClass(), alternate):
             pass
 
+    def test_setattr_in_subclass_is_not_called_creating_an_instance(self):
+        class subclass(self._getTargetClass()):
+            _v_setattr_called = False
+            def __setattr__(self, name, value):
+                object.__setattr__(self, '_v_setattr_called', True)
+                super(subclass,self).__setattr__(name, value)
+        inst = subclass()
+        self.assertEqual(object.__getattribute__(inst,'_v_setattr_called'), False)
 
 class PyPersistentTests(unittest.TestCase, _Persistent_Base):
 


### PR DESCRIPTION
We have some code that subclasses `Persistent` and modifies `_p_changed` handling, something like this:

``` python
class X(Persistent):
    def __setattr__(self, name, value):
        was_changed = self._p_changed
        super(X,self).__setattr__(name, value)
        if not was_changed and some_magic_reason():
            # Actually, we're not changed. Don't try to persist this.
            self._p_changed = False
```

This works fine if we get the C version of Persistent, but if we get the Python version it blows up due to the way `Persistent.__new__` and `Persistent._get_changed` interact with `__setattr__`:

``` python
>>> X()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "persistent/persistence.py", line 56, in __new__
    inst.__jar = None
  File "<console>", line 3, in __setattr__
  File "persistent/persistence.py", line 222, in __getattribute__
    return _OGA(self, name)
  File "persistent/persistence.py", line 118, in _get_changed
    if self.__jar is None:
  File "persistent/persistence.py", line 222, in __getattribute__
    return _OGA(self, name)
AttributeError: _Persistent__jar
```

Is this a bug in the Python version? It is a behaviour difference from the C version. If it's not a bug, is there a suggested workaround? We can alter our code to not read `_p_changed` if `__setattr__` is called with a private property (`name.startswith('_Persistent')`), it just seems a bit unclean to rely on implementation details like that. (Using `Persistent._p_setattr` doesn't work.)

If it is a bug, I'd be happy to submit a PR to test and fix it. I would probably make `__new__` call `object.__setattr__`, bypassing subclasses altogether, unless there are other suggestions.
