### PR TITLE
Python _p_activate can corrupt non-ghost objects and lead to POSKeyErrors for unsaved objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 4.0.8 (Unreleased)
 ------------------
 
+- In pure-Python ``Persistent``, calling ``_p_activate`` no longer
+  corrupts the state of a non-ghost object, and it doesn't throw
+  ``POSKeyError`` if called on an object that has never been committed.
+  (PR #9)
+
 - In pure-Python ``Persistent``, avoid calling a subclass's ``__setattr__``
   at instance creation time. (PR #8)
 

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -330,14 +330,14 @@ class Persistent(object):
         """ See IPersistent.
         """
         before = self.__flags
-        if self.__flags is None:
+        if self.__flags is None or self._p_state < 0: # Only do this if we're a ghost
             self.__flags = 0
-        if self.__jar is not None and self.__oid is not None:
-            try:
-                self.__jar.setstate(self)
-            except:
-                self.__flags = before
-                raise
+            if self.__jar is not None and self.__oid is not None:
+                try:
+                    self.__jar.setstate(self)
+                except:
+                    self.__flags = before
+                    raise
 
     def _p_deactivate(self):
         """ See IPersistent.

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -978,6 +978,19 @@ class _Persistent_Base(object):
         inst._p_activate() # noop from 'saved' state
         self.assertEqual(inst._p_status, 'saved')
 
+    def test__p_activate_only_sets_state_once(self):
+        inst, jar, OID = self._makeOneWithJar()
+        # No matter how many times we call _p_activate, it
+        # only sets state once, the first time
+        inst._p_invalidate() # make it a ghost
+        self.assertEqual(list(jar._loaded), [])
+
+        inst._p_activate()
+        self.assertEqual(list(jar._loaded), [OID])
+
+        inst._p_activate()
+        self.assertEqual(list(jar._loaded), [OID])
+
     def test__p_deactivate_from_unsaved(self):
         inst = self._makeOne()
         inst._p_deactivate()


### PR DESCRIPTION
Previously, `_p_activate` in the pure-python Persistent object didn't check what the object's state was, only whether it had a jar and OID. It unconditionally called `setstate` on the jar if it had those two things. The C version, in contrast, checks it's state and only unghostifies itself if it is known to be a ghost. 

There were two consequences to this behaviour difference. First, if `_p_activate` was ever called more than once on an object that had changes, those changes would get overwritten. Second, if `_p_activate` was called on an object that was newly added to a ZODB connection but not yet committed, ZODB's storage would throw a `POSKeyError` because the OID has only been assigned, it hasn't yet been saved.

It's subtle to see in the diff because it's an indentation difference, but this change makes the Python version also check its state and only unghostify true ghosts.
