### PR TITLE
Make C TimeStamp ctor match Python ref. impl.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@
 4.0.9 (unreleased)
 ------------------
 
-- TBD
+- Make ``h``, ``m``, and ``sec`` arguments to C implementation of
+  ``TimeStamp`` non-optional (matches Python implementation, and ZODB
+  does not use the flexibility).  Issue #13.
 
 4.0.8 (2014-03-20)
 ------------------

--- a/persistent/_timestamp.c
+++ b/persistent/_timestamp.c
@@ -478,7 +478,7 @@ TimeStamp_TimeStamp(PyObject *obj, PyObject *args)
     }
     PyErr_Clear();
 
-    if (!PyArg_ParseTuple(args, "iii|iid", &y, &mo, &d, &h, &m, &sec))
+    if (!PyArg_ParseTuple(args, "iiiiid", &y, &mo, &d, &h, &m, &sec))
         return NULL;
     return TimeStamp_FromDate(y, mo, d, h, m, sec);
 }

--- a/persistent/tests/test_timestamp.py
+++ b/persistent/tests/test_timestamp.py
@@ -59,6 +59,8 @@ class pyTimeStampTests(unittest.TestCase):
                     (1, 2, 3, 4, 5),
                     ('1', '2', '3', '4', '5', '6'),
                     (1, 2, 3, 4, 5, 6, 7),
+                    # https://github.com/zopefoundation/persistent/issues/13
+                    (2014, 2, 3)
                    ]
         for args in BAD_ARGS:
             self.assertRaises((TypeError, ValueError), self._makeOne, *args)


### PR DESCRIPTION
'h', 'm', and 'sec' arguments to 'TimeStamp' are now non-optional.  This
change matches Python implementation, and ZODB does not use the flexibility.

Fixes #13.
