### PR TITLE
fix test___setstate___interns_dict_keys failure on pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
     - 2.7
     - 3.2
     - 3.3
+    - 3.4
     - pypy
+    - pypy3
 install:
     - pip install . --use-mirrors
 script:

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -14,6 +14,12 @@
 import os
 import unittest
 
+import platform
+import sys
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+_is_pypy3 = py_impl() == 'PyPy' and sys.version_info[0] > 2
+
+
 class _Persistent_Base(object):
 
     def _makeOne(self, *args, **kw):
@@ -863,19 +869,20 @@ class _Persistent_Base(object):
         self.assertEqual(inst.baz, 'bam')
         self.assertEqual(inst.qux, 'spam')
 
-    def test___setstate___interns_dict_keys(self):
-        class Derived(self._getTargetClass()):
-            pass
-        inst1 = Derived()
-        inst2 = Derived()
-        key1 = 'key'
-        key2 = 'ke'; key2 += 'y'  # construct in a way that won't intern the literal
-        self.assertFalse(key1 is key2)
-        inst1.__setstate__({key1: 1})
-        inst2.__setstate__({key2: 2})
-        key1 = list(inst1.__dict__.keys())[0]
-        key2 = list(inst2.__dict__.keys())[0]
-        self.assertTrue(key1 is key2)
+    if not _is_pypy3:
+        def test___setstate___interns_dict_keys(self):
+            class Derived(self._getTargetClass()):
+                pass
+            inst1 = Derived()
+            inst2 = Derived()
+            key1 = 'key'
+            key2 = 'ke'; key2 += 'y'  # construct in a way that won't intern the literal
+            self.assertFalse(key1 is key2)
+            inst1.__setstate__({key1: 1})
+            inst2.__setstate__({key2: 2})
+            key1 = list(inst1.__dict__.keys())[0]
+            key2 = list(inst2.__dict__.keys())[0]
+            self.assertTrue(key1 is key2)
 
     def test___reduce__(self):
         from persistent._compat import copy_reg


### PR DESCRIPTION
(by disabling the test, since pypy3 doesn't guarantee identity of intern'd strings)

Not using unittest.skipIf because it doesn't exist in python 2.6.

Also enable travis tests for 3.4 and pypy3