### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 ``persistent`` Changelog
 ========================
 
-4.1.2 (unreleased)
+4.2.0 (unreleased)
 ------------------
 
-- TBD
+- Drop support for Python 2.6 and 3.2.
 
 4.1.1 (2015-06-02)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-__version__ = '4.1.2.dev0'
+__version__ = '4.2.0.dev0'
 
 import os
 import platform
@@ -79,10 +79,8 @@ setup(name='persistent',
         "License :: OSI Approved :: Zope Public License",
         "Programming Language :: Python",
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,18 @@
 envlist =
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
-#   py26,py27,py27-pure,pypy,py32,py33,py34,pypy3,jython,coverage,docs
-    py26,py27,py27-pure,py27-pure-cffi,pypy,py32,py33,py34,pypy3,coverage,docs
+#   py27,py27-pure,pypy,py33,py34,pypy3,jython,coverage,docs
+    py27,py27-pure,py27-pure-cffi,pypy,py33,py34,pypy3,coverage,docs
 
 [testenv]
 deps =
     zope.interface
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
 [testenv:jython]
 commands =
-   jython setup.py test -q
+   jython setup.py -q test -q
 
 [testenv:py27-pure]
 basepython =
@@ -23,7 +23,7 @@ setenv =
 deps =
     {[testenv]deps}
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
 [testenv:py27-pure-cffi]
 basepython =
@@ -35,12 +35,12 @@ deps =
     {[testenv]deps}
     cffi
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
 
 [testenv:coverage]
 basepython =
-    python2.6
+    python2.7
 setenv =
     USING_CFFI = 1
 commands =
@@ -54,7 +54,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python2.6
+    python2.7
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.