### PR TITLE
Don't use/poison global wheel cache when building w/ PURE_PYTHON.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 4.2.0 (unreleased)
 ------------------
 
+- When testing ``PURE_PYTHON`` environments under ``tox``, avoid poisoning
+  the user's global wheel cache.
+
 - Drop support for Python 2.6 and 3.2.
 
 4.1.1 (2015-06-02)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ basepython =
     python2.7
 setenv =
     PURE_PYTHON = 1
+    PIP_CACHE_DIR = {envdir}/.cache
 deps =
     {[testenv]deps}
 commands =
@@ -30,6 +31,7 @@ basepython =
     python2.7
 setenv =
     PURE_PYTHON = 1
+    PIP_CACHE_DIR = {envdir}/.cache
     USING_CFFI = 1
 deps =
     {[testenv]deps}


### PR DESCRIPTION
The `none-any` wheels built in the PURE_PYTHON environments should not poison the user's global wheel cache.