### PR TITLE
TimeStamp: sub-second precision for Python implementation of timeTime()

### DIFF
--- a/persistent/tests/test_timestamp.py
+++ b/persistent/tests/test_timestamp.py
@@ -100,9 +100,10 @@ class pyTimeStampTests(unittest.TestCase):
         self.assertEqual(ts.timeTime(), DELTA_SECS)
 
     def test_ctor_from_string_non_zero(self):
-        before = self._makeOne(2011, 2, 16, 14, 37, 22.0)
+        before = self._makeOne(2011, 2, 16, 14, 37, 22.80544)
         after = self._makeOne(before.raw())
         self.assertEqual(before.raw(), after.raw())
+        self.assertEqual(before.timeTime(), 1297867042.80544)
 
     def test_ctor_from_elements(self):
         from persistent.timestamp import _makeOctets

--- a/persistent/timestamp.py
+++ b/persistent/timestamp.py
@@ -119,7 +119,7 @@ class pyTimeStamp(object):
         """ -> seconds since epoch, as a float.
         """
         delta = _makeUTC(*self._elements) - _EPOCH
-        return delta.days * 86400.0 + delta.seconds
+        return delta.days * 86400 + delta.seconds + delta.microseconds / 1e6
 
     def laterThan(self, other):
         """ Return a timestamp instance which is later than 'other'.


### PR DESCRIPTION
The fractional part of return values was always 0.