### PR TITLE
Make calls to unghost a cPersistent.Persistent object available in python

### DIFF
--- a/persistent/__init__.py
+++ b/persistent/__init__.py
@@ -26,6 +26,9 @@ if not PURE_PYTHON:
         from persistent.cPersistence import CHANGED
         from persistent.cPersistence import STICKY
         from persistent.cPersistence import simple_new
+        from persistent.cPersistence import PER_USE
+        from persistent.cPersistence import PER_ALLOW_DEACTIVATION
+        from persistent.cPersistence import PER_ACCESSED
     except ImportError: #pragma NO COVER
         from persistent.persistence import Persistent
         from persistent.persistence import GHOST

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -1437,11 +1437,60 @@ simple_new(PyObject *self, PyObject *type_object)
     return PyType_GenericNew((PyTypeObject *)type_object, NULL, NULL);
 }
 
+static PyObject*
+py_per_use(PyObject* self, PyObject* ob) {
+    if (!PER_TypeCheck(ob)) {
+        return PyErr_Format(
+            PyExc_TypeError,
+            "object of type %s does not inherit from cPersistence.Persistent",
+            Py_TYPE(ob)->tp_name
+        );
+    }
+
+    if (PER_USE((cPersistentObject*) ob)) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+py_per_allow_deactivation(PyObject* self, PyObject* ob) {
+    if (!PER_TypeCheck(ob)) {
+        return PyErr_Format(
+            PyExc_TypeError,
+            "object of type %s does not inherit from cPersistence.Persistent",
+            Py_TYPE(ob)->tp_name
+        );
+    }
+
+    PER_ALLOW_DEACTIVATION((cPersistentObject*) ob);
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+py_per_accessed(PyObject* self, PyObject* ob) {
+    if (!PER_TypeCheck(ob)) {
+        return PyErr_Format(
+            PyExc_TypeError,
+            "object of type %s does not inherit from cPersistence.Persistent",
+            Py_TYPE(ob)->tp_name
+        );
+    }
+
+    PER_ACCESSED((cPersistentObject*) ob);
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef cPersistence_methods[] =
 {
     {"simple_new", simple_new, METH_O,
      "Create an object by simply calling a class's __new__ method without "
      "arguments."},
+    {"PER_USE", py_per_use, METH_O, ""},
+    {"PER_ALLOW_DEACTIVATION", py_per_allow_deactivation, METH_O, ""},
+    {"PER_ACCESSED", py_per_accessed, METH_O, ""},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Hello,

I had a look in porting https://github.com/zopefoundation/Persistence to python3.
@hannosch added already support for the python version of persistent.
However we have seen problems if the C-Extensions of persistent is available.
In that case the python version of Persistence needs access to the C-code of persistent to unghostify objects (per_use, allow_deactivation, accessed)

My goal would be to implement  **getattribute** like this.

```
    def __getattribute__(self, key):

        if (not name.startswith('_p_') and name not in _SPECIAL_NAMES):
            persistent.PER_USE(self)
            v = ExtensionClass.Base_getattro(self, key)
            persistent.PER_ALLOW_DEACTIVATION(self)
            persistent.PER_ACCESSED(self)
        else:
            v = ExtensionClass.Base_getattro(self, key)
        return v
```

This pull request simply exposes some of the calls in cPersistence.h to python.

I know in a ideal world we would use the C-Extension of Persistence, so persistent.cPersistence.h can be used directly.
Unfortunately Persistence uses the C-Extension of ExtensionClass which is not ported to python3 (yet?).

If you don't like this pull request at all, I could add a mini C-Extension to Persistence which exposes the calls of persistent.cPersistence.h to python too.
