### PR TITLE
Stop calling gc.collect in the Python incrgc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 4.2.2 (2016-11-29)
 ------------------
 
+- Stop calling ``gc.collect`` every time ``PickleCache.incrgc`` is called (every
+  transaction boundary) in pure-Python mode (PyPy). This means that
+  the reported size of the cache may be wrong (until the next GC), but
+  it is much faster. This should not have any observable effects for
+  user code.
+
 - Drop use of ``ctypes`` for determining maximum integer size, to increase
   pure-Python compatibility. See https://github.com/zopefoundation/persistent/pull/31
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,14 +7,15 @@
 - Fix the hashcode of Python ``TimeStamp`` objects on 64-bit Python on
   Windows. See https://github.com/zopefoundation/persistent/pull/55
 
-4.2.2 (2016-11-29)
-------------------
-
 - Stop calling ``gc.collect`` every time ``PickleCache.incrgc`` is called (every
   transaction boundary) in pure-Python mode (PyPy). This means that
   the reported size of the cache may be wrong (until the next GC), but
   it is much faster. This should not have any observable effects for
   user code.
+
+
+4.2.2 (2016-11-29)
+------------------
 
 - Drop use of ``ctypes`` for determining maximum integer size, to increase
   pure-Python compatibility. See https://github.com/zopefoundation/persistent/pull/31

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -30,13 +30,9 @@ class PickleCacheTests(unittest.TestCase):
         self.orig_types = persistent.picklecache._CACHEABLE_TYPES
         persistent.picklecache._CACHEABLE_TYPES += (DummyPersistent,)
 
-        self.orig_sweep_gc = persistent.picklecache._SWEEP_NEEDS_GC
-        persistent.picklecache._SWEEP_NEEDS_GC = True # coverage
-
     def tearDown(self):
         import persistent.picklecache
         persistent.picklecache._CACHEABLE_TYPES = self.orig_types
-        persistent.picklecache._SWEEP_NEEDS_GC = self.orig_sweep_gc
 
     def _getTargetClass(self):
         from persistent.picklecache import PickleCache
@@ -992,7 +988,7 @@ class PickleCacheTests(unittest.TestCase):
             return f
 
     @with_deterministic_gc
-    def test_cache_garbage_collection_bytes_also_deactivates_object(self, force_collect=False):
+    def test_cache_garbage_collection_bytes_also_deactivates_object(self, force_collect=_is_pypy or _is_jython):
         from persistent.interfaces import UPTODATE
         from persistent._compat import _b
         cache = self._makeOne()


### PR DESCRIPTION
@jimfulton and I have talked about it, and I'm (mostly :) convinced that
this shouldn't be an actual problem for any of the reasons described in
the previous comment.

Running the GC every time slows down one of Jim's benchmarks by up to 10x. It all depends on the frequency of the transactions relative to application work.

If I use PyPy 5.4.1 to run the ZODB master test suite against
this (well, with #44 rolled back) I don't get any unexpected
failures. (I haven't run the ZEO test suite yet.) Which honestly amazes
me because I'm sure I used to get test failures---I guess the PyPy GC
has changed...which means we may see some failures on Travis. I'll try
to set up an older PyPy to verify.

(ZODB tests won't run with current master until #44 is addressed somehow.)
