### PR TITLE
On deactivate release in-slots objects only for classes that don't ov…

### DIFF
--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -424,8 +424,11 @@ class Persistent(object):
         if idict is not None:
             idict.clear()
         type_ = type(self)
-        for slotname in Persistent._slotnames(self, _v_exclude=False):
-            getattr(type_, slotname).__delete__(self)
+        # ( for backward-compatibility reason we release __slots__ only if
+        #   class does not override __new__ )
+        if type_.__new__ is Persistent.__new__:
+            for slotname in Persistent._slotnames(self, _v_exclude=False):
+                getattr(type_, slotname).__delete__(self)
 
         # Implementation detail: deactivating/invalidating
         # updates the size of the cache (if we have one)


### PR DESCRIPTION
…erride __new__

Commit fe2219f4 taught Persistent to release in-slots objects on
deactivation. That however broke pure-python implementation of many
things because they were using __slots__ as a place which survive
deactivation.

As per discussion in

    https://github.com/zopefoundation/persistent/pull/44

and resolution:

    https://github.com/zopefoundation/persistent/pull/44#issuecomment-261019084

let's try to preserve backward compatibility by not releasing slots for
classes that override __new__

/proposed-by @jimfulton