### PR TITLE
new_ghost shouldn't clear newargs (PyPy consistent with C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 .installed.cfg
 .dir-locals.el
 dist
+htmlcov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 4.2.2 (2016-11-29)
 ------------------
 
+- Stop calling ``gc.collect`` every time ``PickleCache.incrgc`` is called (every
+  transaction boundary) in pure-Python mode (PyPy). This means that
+  the reported size of the cache may be wrong (until the next GC), but
+  it is much faster. This should not have any observable effects for
+  user code.
+
 - Drop use of ``ctypes`` for determining maximum integer size, to increase
   pure-Python compatibility. See https://github.com/zopefoundation/persistent/pull/31
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,14 +7,20 @@
 - Fix the hashcode of Python ``TimeStamp`` objects on 64-bit Python on
   Windows. See https://github.com/zopefoundation/persistent/pull/55
 
-4.2.2 (2016-11-29)
-------------------
-
 - Stop calling ``gc.collect`` every time ``PickleCache.incrgc`` is called (every
   transaction boundary) in pure-Python mode (PyPy). This means that
   the reported size of the cache may be wrong (until the next GC), but
   it is much faster. This should not have any observable effects for
   user code.
+
+- Stop clearing the dict and slots of objects added to
+  ``PickleCache.new_ghost`` (typically these values are passed to
+  ``__new__`` from the pickle data) in pure-Python mode (PyPy). This
+  matches the behaviour of the C code.
+
+
+4.2.2 (2016-11-29)
+------------------
 
 - Drop use of ``ctypes`` for determining maximum integer size, to increase
   pure-Python compatibility. See https://github.com/zopefoundation/persistent/pull/31

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -422,8 +422,11 @@ class Persistent(object):
             _OSA(self, '_Persistent__flags', None)
 
         if clear:
-            idict = _OGA(self, '__dict__', None)
-            if idict is not None:
+            try:
+                idict = _OGA(self, '__dict__')
+            except AttributeError:
+                pass
+            else:
                 idict.clear()
             type_ = type(self)
             # for backward-compatibility reason we release __slots__ only if

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -413,27 +413,29 @@ class Persistent(object):
         _OSA(self, '_Persistent__flags', 0)
         self._p_deactivate()
 
-    def _p_invalidate_deactivate_helper(self):
+    def _p_invalidate_deactivate_helper(self, clear=True):
         jar = _OGA(self, '_Persistent__jar')
         if jar is None:
             return
 
         if _OGA(self, '_Persistent__flags') is not None:
             _OSA(self, '_Persistent__flags', None)
-        idict = getattr(self, '__dict__', None)
-        if idict is not None:
-            idict.clear()
-        type_ = type(self)
-        # ( for backward-compatibility reason we release __slots__ only if
-        #   class does not override __new__ )
-        if type_.__new__ is Persistent.__new__:
-            for slotname in Persistent._slotnames(self, _v_exclude=False):
-                try:
-                    getattr(type_, slotname).__delete__(self)
-                except AttributeError:
-                    # AttributeError means slot variable was not initialized at all -
-                    # - we can simply skip its deletion.
-                    pass
+
+        if clear:
+            idict = _OGA(self, '__dict__', None)
+            if idict is not None:
+                idict.clear()
+            type_ = type(self)
+            # for backward-compatibility reason we release __slots__ only if
+            # class does not override __new__
+            if type_.__new__ is Persistent.__new__:
+                for slotname in Persistent._slotnames(self, _v_exclude=False):
+                    try:
+                        getattr(type_, slotname).__delete__(self)
+                    except AttributeError:
+                        # AttributeError means slot variable was not initialized at all -
+                        # - we can simply skip its deletion.
+                        pass
 
         # Implementation detail: deactivating/invalidating
         # updates the size of the cache (if we have one)

--- a/persistent/picklecache.py
+++ b/persistent/picklecache.py
@@ -246,7 +246,7 @@ class PickleCache(object):
                 # careful to avoid broken _p_invalidate and _p_deactivate
                 # that don't call the super class. See ZODB's
                 # testConnection.doctest_proper_ghost_initialization_with_empty__p_deactivate
-                obj._p_invalidate_deactivate_helper()
+                obj._p_invalidate_deactivate_helper(False)
         self[oid] = obj
 
     def reify(self, to_reify):

--- a/persistent/picklecache.py
+++ b/persistent/picklecache.py
@@ -21,7 +21,7 @@ from persistent.interfaces import GHOST
 from persistent.interfaces import IPickleCache
 from persistent.interfaces import OID_TYPE
 from persistent.interfaces import UPTODATE
-from persistent import Persistent
+from persistent.persistence import Persistent
 from persistent.persistence import _estimated_size_in_24_bits
 
 # Tests may modify this to add additional types

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -1066,7 +1066,9 @@ class DummyPersistent(object):
         self._p_state = GHOST
 
     _p_deactivate = _p_invalidate
-    _p_invalidate_deactivate_helper = _p_invalidate
+
+    def _p_invalidate_deactivate_helper(self, clear=True):
+        self._p_invalidate()
 
     def _p_activate(self):
         from persistent.interfaces import UPTODATE

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -30,13 +30,9 @@ class PickleCacheTests(unittest.TestCase):
         self.orig_types = persistent.picklecache._CACHEABLE_TYPES
         persistent.picklecache._CACHEABLE_TYPES += (DummyPersistent,)
 
-        self.orig_sweep_gc = persistent.picklecache._SWEEP_NEEDS_GC
-        persistent.picklecache._SWEEP_NEEDS_GC = True # coverage
-
     def tearDown(self):
         import persistent.picklecache
         persistent.picklecache._CACHEABLE_TYPES = self.orig_types
-        persistent.picklecache._SWEEP_NEEDS_GC = self.orig_sweep_gc
 
     def _getTargetClass(self):
         from persistent.picklecache import PickleCache
@@ -992,7 +988,7 @@ class PickleCacheTests(unittest.TestCase):
             return f
 
     @with_deterministic_gc
-    def test_cache_garbage_collection_bytes_also_deactivates_object(self, force_collect=False):
+    def test_cache_garbage_collection_bytes_also_deactivates_object(self, force_collect=_is_pypy or _is_jython):
         from persistent.interfaces import UPTODATE
         from persistent._compat import _b
         cache = self._makeOne()


### PR DESCRIPTION
Fixes #49. Tested with ZODB, ZEO, zope.container.

(Includes #47 , rebased on master and tested with PyPy on ZEO and ZODB, because when I created this branch I expected that PR to be merged already by the time this was ready.)