### PR TITLE
Fix Python timestamp hash on 64-bit windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 ------------------
 
 - Drop use of ``ctypes`` for determining maximum integer size, to increase
-  pure-Python compatibility.
+  pure-Python compatibility. See https://github.com/zopefoundation/persistent/pull/31
 
 - Ensure that ``__slots__`` attributes are cleared when a persistent
   object is ghostified.  (This excluses classes that override

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 ``persistent`` Changelog
 ========================
 
+4.2.3 (unreleased)
+------------------
+
+- Fix the hashcode of Python ``TimeStamp`` objects on 64-bit Python on
+  Windows. See https://github.com/zopefoundation/persistent/pull/55
+
 4.2.2 (2016-11-29)
 ------------------
 

--- a/persistent/tests/test_timestamp.py
+++ b/persistent/tests/test_timestamp.py
@@ -280,26 +280,13 @@ class PyAndCComparisonTests(unittest.TestCase):
 
         is_32_bit_hash = orig_maxint == MAX_32_BITS
 
-        orig_c_long = None
-        c_int64 = None
-        c_int32 = None
-        if hasattr(MUT, 'c_long'):
-            import ctypes
-            orig_c_long = MUT.c_long
-            c_int32 = ctypes.c_int32
-            c_int64 = ctypes.c_int64
-            # win32, even on 64-bit long, has funny sizes
-            is_32_bit_hash = c_int32 == ctypes.c_long
-
         try:
             MUT._MAXINT = MAX_32_BITS
-            MUT.c_long = c_int32
 
             py = self._makePy(*self.now_ts_args)
             self.assertEqual(hash(py), bit_32_hash)
 
             MUT._MAXINT = int(2 ** 63 - 1)
-            MUT.c_long = c_int64
             # call __hash__ directly to avoid interpreter truncation
             # in hash() on 32-bit platforms
             if not self._is_jython:
@@ -316,10 +303,6 @@ class PyAndCComparisonTests(unittest.TestCase):
                     384009219096809580920179179233996861765753210540033)
         finally:
             MUT._MAXINT = orig_maxint
-            if orig_c_long is not None:
-                MUT.c_long = orig_c_long
-            else:
-                del MUT.c_long
 
         # These are *usually* aliases, but aren't required
         # to be (and aren't under Jython 2.7).
@@ -334,7 +317,7 @@ class PyAndCComparisonTests(unittest.TestCase):
         import persistent.timestamp as MUT
         # We get 32-bit hash values on 32-bit platforms, or on the JVM
         # OR on Windows (whether compiled in 64 or 32-bit mode)
-        is_32_bit = MUT._MAXINT == (2**31 - 1) or self._is_jython or sys.platform == 'win32'
+        is_32_bit = MUT._MAXINT == (2**31 - 1) or self._is_jython
 
         c, py = self._make_C_and_Py(b'\x00\x00\x00\x00\x00\x00\x00\x00')
         self.assertEqual(hash(c), 8)

--- a/persistent/tests/test_timestamp.py
+++ b/persistent/tests/test_timestamp.py
@@ -280,13 +280,26 @@ class PyAndCComparisonTests(unittest.TestCase):
 
         is_32_bit_hash = orig_maxint == MAX_32_BITS
 
+        orig_c_long = None
+        c_int64 = None
+        c_int32 = None
+        if hasattr(MUT, 'c_long'):
+            import ctypes
+            orig_c_long = MUT.c_long
+            c_int32 = ctypes.c_int32
+            c_int64 = ctypes.c_int64
+            # win32, even on 64-bit long, has funny sizes
+            is_32_bit_hash = c_int32 == ctypes.c_long
+
         try:
             MUT._MAXINT = MAX_32_BITS
+            MUT.c_long = c_int32
 
             py = self._makePy(*self.now_ts_args)
             self.assertEqual(hash(py), bit_32_hash)
 
             MUT._MAXINT = int(2 ** 63 - 1)
+            MUT.c_long = c_int64
             # call __hash__ directly to avoid interpreter truncation
             # in hash() on 32-bit platforms
             if not self._is_jython:
@@ -303,6 +316,10 @@ class PyAndCComparisonTests(unittest.TestCase):
                     384009219096809580920179179233996861765753210540033)
         finally:
             MUT._MAXINT = orig_maxint
+            if orig_c_long is not None:
+                MUT.c_long = orig_c_long
+            else:
+                del MUT.c_long
 
         # These are *usually* aliases, but aren't required
         # to be (and aren't under Jython 2.7).
@@ -317,7 +334,7 @@ class PyAndCComparisonTests(unittest.TestCase):
         import persistent.timestamp as MUT
         # We get 32-bit hash values on 32-bit platforms, or on the JVM
         # OR on Windows (whether compiled in 64 or 32-bit mode)
-        is_32_bit = MUT._MAXINT == (2**31 - 1) or self._is_jython
+        is_32_bit = MUT._MAXINT == (2**31 - 1) or self._is_jython or sys.platform == 'win32'
 
         c, py = self._make_C_and_Py(b'\x00\x00\x00\x00\x00\x00\x00\x00')
         self.assertEqual(hash(c), 8)

--- a/persistent/timestamp.py
+++ b/persistent/timestamp.py
@@ -29,12 +29,19 @@ def _makeOctets(s):
 
 _ZERO = _makeOctets('\x00' * 8)
 
-
-def _wraparound(x):
+try:
     # Make sure to overflow and wraparound just
     # like the C code does.
-    return int(((x + (_MAXINT + 1)) & ((_MAXINT << 1) + 1)) - (_MAXINT + 1))
-
+    from ctypes import c_long
+except ImportError: # pragma: no cover
+    # XXX: This is broken on 64-bit windows, where
+    # sizeof(long) != sizeof(Py_ssize_t)
+    # sizeof(long) == 4, sizeof(Py_ssize_t) == 8
+    def _wraparound(x):
+        return int(((x + (_MAXINT + 1)) & ((_MAXINT << 1) + 1)) - (_MAXINT + 1))
+else:
+    def _wraparound(x):
+        return c_long(x).value
 
 class _UTC(datetime.tzinfo):
     def tzname(self):


### PR DESCRIPTION
Fixes #51

Part of the problem was in the tests. The detection of when the hash
gets truncated was broken on win32.

Part of the problem is somewhere in the _wraparound function, I think,
because even fixing the tests to use the right values we still get
mismatches. Rather than dig into that, I just go back to using ctypes
when it's available.