### PR TITLE
Python 3.6 Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 sudo: false
 matrix:
     include:
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='homebrew 3.6'
         - os: linux
           python: 2.7
         - os: linux
@@ -27,7 +24,13 @@ matrix:
           env: TERRYFY_PYTHON='macpython 3.4'
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='homebrew 3.5'
+          env: TERRYFY_PYTHON='macpython 3.5'
+        # Homebrew only accepts the major version number and
+        # automatically rolls out new versions. At this writing, that
+        # is 3.6.0.
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='homebrew 3'
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='macpython 3.6'
+          env: TERRYFY_PYTHON='homebrew 3.6'
         - os: linux
           python: 2.7
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 sudo: false
 matrix:
     include:
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='macpython 3.6'
         - os: linux
           python: 2.7
         - os: linux
@@ -33,6 +36,7 @@ before_install:
 install:
     - pip install -e .
 script:
+    - python --version
     - python setup.py -q test -q
 notifications:
     email: false


### PR DESCRIPTION
Added at the top to see if it would change the build order. Turns out it doesn't, they're grouped by OS and the linux builds go first (and faster). (I would move it down with the others, but then there'd have to be another build and it's taking more than an hour now for the mac builds to start.)