### PR TITLE
Use macpython for all Mac builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,21 @@ matrix:
           python: pypy
         - os: linux
           python: pypy3
+        # It's important to use 'macpython' builds to get the least
+        # restrictive wheel tag. It's also important to avoid
+        # 'homebrew 3' because it floats instead of being a specific version.
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='homebrew 2'
+          env: TERRYFY_PYTHON='macpython 2.7'
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.4'
         - os: osx
           language: generic
           env: TERRYFY_PYTHON='macpython 3.5'
-        # Homebrew only accepts the major version number and
-        # automatically rolls out new versions. At this writing, that
-        # is 3.6.0.
         - os: osx
           language: generic
-          env: TERRYFY_PYTHON='homebrew 3'
+          env: TERRYFY_PYTHON='macpython 3.6.0'
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi


### PR DESCRIPTION
Ref #58. This should get us the right wheel tags and hopefully the non-floating 3.6 build (until 'multibuild' from terryfy is updated we have to use a specific 3.6.0 version).

Fingers crossed.

EDIT: I forgot zope.interface from the list of things with C extensions.
EDIT2: Oh, and I guess zope.index has an *optional* extension.