### PR TITLE
Change cPickleCache to use PER_TypeCheck

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,20 @@
 ``persistent`` Changelog
 ========================
 
-4.2.5 (unreleased)
+4.3.0 (unreleased)
 ------------------
 
 - Fix the possibility of a rare crash in the C extension when
   deallocating items. See https://github.com/zopefoundation/persistent/issues/66
 
+- Change cPickleCache's comparison of object sizes to determine
+  whether an object can go in the cache to use ``PyObject_TypeCheck()``.
+  This matches what the pure Python implementation does and is a
+  stronger test that the object really is compatible with the cache.
+  Previously, an object could potentially include ``cPersistent_HEAD``
+  and *not* set ``tp_base`` to ``cPersistenceCAPI->pertype`` and still
+  be eligible for the pickle cache; that is no longer the case. See
+  `issue 69 <https://github.com/zopefoundation/persistent/issues/69>`_.
 
 4.2.4.2 (2017-04-23)
 --------------------


### PR DESCRIPTION
Instead of testing object sizes.

This matches what the pure Python implementation does and is a stronger test that the object really is compatible with the cache. Previously, an object could potentially include ``cPersistent_HEAD``
and *not* set ``tp_base`` to ``cPersistenceCAPI->pertype`` and still be eligible for the pickle cache; that is no longer the case.

This resolves several compiler warnings:
```
persistent/cPickleCache.c:521:43: warning: comparison of integers of different signs: 'Py_ssize_t' (aka 'long') and 'unsigned long' [-Wsign-compare]
                (v->ob_type->tp_basicsize >= sizeof(cPersistentObject))
                 ~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~
persistent/cPickleCache.c:709:39: warning: comparison of integers of different signs: 'Py_ssize_t' (aka 'long') and 'unsigned long' [-Wsign-compare]
    else if (v->ob_type->tp_basicsize < sizeof(cPersistentObject))
```
Fixes #69.

I ran the BTree tests with this version of persistent installed and they passed, as did the tests for zope.container. Those were the two projects I could think of that have persistent subclasses in C.