### PR TITLE
Switch to zope.testrunner from 'python setup.py test' and 'nose'.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
+[run]
+source = persistent
+
 [report]
 exclude_lines =
     # pragma: no cover
     class I[A-Z]\w+\((Interface|I[A-Z].*)\):
+    raise NotImplementedError
+    raise AssertionError

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -5,7 +5,6 @@ set -e -x
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
-       [[ "${PYBIN}" == *"cp33"* ]] || \
        [[ "${PYBIN}" == *"cp34"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,11 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
 install:
-    - pip install -e .
+    - pip install -U pip setuptools
+    - pip install -U -e .[test]
 script:
     - python --version
-    - python setup.py -q test -q
+    - zope-testrunner --test-path=. --auto-color --auto-progress
 notifications:
     email: false
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,14 @@ environment:
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
-  - pip install -e .
+  - python -m pip install -U pip setuptools wheel
+  - pip install -e .[test]
 
 build_script:
-  - pip install wheel
   - python -W ignore setup.py -q bdist_wheel
 
 test_script:
-  - python setup.py -q test -q
+  - python -m zope.testrunner --test-path=.
 
 artifacts:
   - path: 'dist\*.whl'

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -17,8 +17,7 @@ import platform
 import sys
 import unittest
 
-_py_impl = getattr(platform, 'python_implementation', lambda: None)
-_is_pypy = _py_impl() == 'PyPy'
+_is_pypy = platform.python_implementation() == 'PyPy'
 _is_jython = 'java' in sys.platform
 
 _marker = object()
@@ -1054,10 +1053,12 @@ class PickleCacheTests(unittest.TestCase):
     def test_ring_impl(self):
         from .. import ring
 
-        if _is_pypy or os.getenv('USING_CFFI'):
-            self.assertTrue(ring.Ring is ring._CFFIRing)
+        if _is_pypy:
+            self.assertIs(ring.Ring, ring._CFFIRing)
+        elif ring._CFFIRing is not None:
+            self.assertIs(ring.Ring, ring._CFFIRing)
         else:
-            self.assertTrue(ring.Ring is ring._DequeRing)
+            self.assertIs(ring.Ring, ring._DequeRing)
 
 class DummyPersistent(object):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[nosetests]
-nocapture=1
-cover-package=persistent
-cover-erase=1
-cover-branches=1
-cover-min-percentage=100
-with-doctest=0
-where=persistent
-
 [aliases]
 dev = develop easy_install persistent[testing]
 docs = develop easy_install persistent[docs]

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,13 @@ def _read_file(filename):
 
 README = (_read_file('README.rst') + '\n\n' + _read_file('CHANGES.rst'))
 
-py_impl = getattr(platform, 'python_implementation', lambda: None)
-is_pypy = py_impl() == 'PyPy'
+is_pypy = platform.python_implementation() == 'PyPy'
 is_jython = 'java' in sys.platform
-is_pure = os.environ.get('PURE_PYTHON')
 
 # Jython cannot build the C optimizations, while on PyPy they are
 # anti-optimizations (the C extension compatibility layer is known-slow,
 # and defeats JIT opportunities).
-if is_pypy or is_jython or is_pure:
+if is_pypy or is_jython:
     ext_modules = headers = []
 else:
     ext_modules = [
@@ -114,17 +112,16 @@ setup(name='persistent',
       ext_modules=ext_modules,
       headers=headers,
       extras_require={
-          'test': (),
-          'testing': [
-              'nose',
-              'coverage',
+          'test': [
+              'zope.testrunner',
+              "cffi ; platform_python_implementation == 'CPython'",
           ],
+          'testing': (),
           'docs': [
               'Sphinx',
               'repoze.sphinx.autointerface',
           ],
       },
-      test_suite="persistent.tests",
       install_requires=[
           'zope.interface',
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,52 +7,36 @@ envlist =
 
 [testenv]
 deps =
-    zope.interface
+    .[test]
 commands =
-    python setup.py -q test -q
-
-[testenv:jython]
-commands =
-   jython setup.py -q test -q
+    zope-testrunner --test-path=.
 
 [testenv:py27-pure]
 basepython =
     python2.7
 setenv =
     PURE_PYTHON = 1
-    PIP_CACHE_DIR = {envdir}/.cache
-deps =
-    {[testenv]deps}
-commands =
-    python setup.py -q test -q
 
 [testenv:py27-pure-cffi]
 basepython =
     python2.7
 setenv =
     PURE_PYTHON = 1
-    PIP_CACHE_DIR = {envdir}/.cache
     USING_CFFI = 1
-deps =
-    {[testenv]deps}
-    cffi
-commands =
-    python setup.py -q test -q
-
 
 [testenv:coverage]
+usedevelop = true
 basepython =
-    python2.7
-setenv =
-    USING_CFFI = 1
+    python3.6
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=.
+    coverage report --fail-under=93
 deps =
-    zope.interface
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover
-    cffi
+setenv =
+    PURE_PYTHON = 1
+    USING_CFFI = 1
 
 [testenv:docs]
 basepython =
@@ -61,6 +45,4 @@ commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    zope.interface
-    Sphinx
-    repoze.sphinx.autointerface
+    .[docs]


### PR DESCRIPTION
Both are essentially deprecated. This is a step in producing usable coverage numbers.

Since we support PURE_PYTHON at runtime, always build the C extensions on supported platforms so that they go in the wheel. This avoids any issue with polluting the wheel cache.

(Also remove cp33 from the manylinux build. This was missed in https://github.com/zopefoundation/persistent/pull/74)