### PR TITLE
Include OID and jar in default repr of Persistent; let subclasses implement _p_repr for exception safety

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@
 4.3.1 (unreleased)
 ------------------
 
+- Change the default representation of ``Persistent`` objects to
+  include the representation of their OID and jar, if set. Also add
+  the ability for subclasses to implement ``_p_repr()`` instead of
+  overriding ``__repr__`` for better exception handling. See `issue 11
+  <https://github.com/zopefoundation/persistent/issues/11>`_.
+
 - Reach and maintain 100% test coverage.
 
 - Simplify ``__init__.py``, including removal of an attempted legacy

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -1,9 +1,10 @@
-Using :mod:`persistent` in your application
-===========================================
+=============================================
+ Using :mod:`persistent` in your application
+=============================================
 
 
 Inheriting from :class:`persistent.Persistent`
-----------------------------------------------
+==============================================
 
 The basic mechanism for making your application's objects persistent
 is mix-in interitance.  Instances whose classes derive from
@@ -14,7 +15,7 @@ they have been changed.
 
 
 Relationship to a Data Manager and its Cache
---------------------------------------------
+============================================
 
 Except immediately after their creation, persistent objects are normally
 associated with a :term:`data manager` (also referred to as a :term:`jar`).
@@ -63,7 +64,7 @@ The examples below use a stub data manager class, and its stub cache class:
 
 
 Persistent objects without a Data Manager
------------------------------------------
+=========================================
 
 Before aersistent instance has been associtated with a a data manager (
 i.e., its ``_p_jar`` is still ``None``).
@@ -166,7 +167,7 @@ Try all sorts of different ways to change the object's state:
 
 
 Associating an Object with a Data Manager
------------------------------------------
+=========================================
 
 Once associated with a data manager, a persistent object's behavior changes:
 
@@ -219,7 +220,7 @@ control the state as described below, or use a
 :class:`~.PersistentList` or :class:`~.PersistentMapping`.
 
 Explicitly controlling ``_p_state``
------------------------------------
+===================================
 
 Persistent objects expose three methods for moving an object into and out
 of the "ghost" state::  :meth:`persistent.Persistent._p_activate`,
@@ -328,7 +329,7 @@ which is exactly the same as calling ``_p_activate``:
 
 
 The pickling protocol
----------------------
+=====================
 
 Because persistent objects need to control how they are pickled and
 unpickled, the :class:`persistent.Persistent` base class overrides
@@ -382,7 +383,7 @@ The ``_p_serial`` attribute is not affected by calling setstate.
 
 
 Estimated Object Size
----------------------
+=====================
 
 We can store a size estimation in ``_p_estimated_size``. Its default is 0.
 The size estimation can be used by a cache associated with the data manager
@@ -412,7 +413,7 @@ Of course, the estimated size must not be negative.
 
 
 Overriding the attribute protocol
----------------------------------
+=================================
 
 Subclasses which override the attribute-management methods provided by
 :class:`persistent.Persistent`, but must obey some constraints:
@@ -448,3 +449,24 @@ Subclasses which override the attribute-management methods provided by
 :meth:`__getattr__`
   For the ``__getattr__`` method, the behavior is like that for regular Python
   classes and for earlier versions of ZODB 3.
+
+
+Implementing ``_p_repr``
+========================
+
+Subclasses can implement ``_p_repr`` to provide a custom
+representation. If this method raises an exception, the default
+representation will be used. The benefit of implementing ``_p_repr``
+instead of overriding ``__repr__`` is that it provides safer handling
+for objects that can't be activated because their persistent data is
+missing or their jar is closed.
+
+.. doctest::
+
+   >>> class P(Persistent):
+   ...    def _p_repr(self):
+   ...        return "Custom repr"
+
+   >>> p = P()
+   >>> print(repr(p))
+   Custom repr

--- a/persistent/interfaces.py
+++ b/persistent/interfaces.py
@@ -166,6 +166,14 @@ class IPersistent(Interface):
     these objects are invalidated, they immediately reload their state
     from their data manager, and are then in the saved state.
 
+    reprs
+
+    By default, persistent objects include the reprs of their
+    _p_oid and _p_jar, if any, in their repr. If a subclass implements
+    the optional method ``_p_repr``, it will be called and its results returned
+    instead of the default repr; if this method raises an exception, that
+    exception will be caught and its repr included in the default repr.
+
     """
 
     _p_jar = Attribute(
@@ -314,10 +322,10 @@ class IPersistent(Interface):
 
     def _p_getattr(name):
         """Test whether the base class must handle the name
-   
+
         The method unghostifies the object, if necessary.
         The method records the object access, if necessary.
- 
+
         This method should be called by subclass __getattribute__
         implementations before doing anything else. If the method
         returns True, then __getattribute__ implementations must delegate
@@ -471,7 +479,7 @@ class IPickleCache(Interface):
         """ Perform an incremental garbage collection sweep.
 
         o Reduce number of non-ghosts to 'cache_size', if possible.
-        
+
         o Ghostify in LRU order.
 
         o Skip dirty or sticky objects.
@@ -505,7 +513,7 @@ class IPickleCache(Interface):
 
         If the object's '_p_jar' is not None, raise.
 
-        If 'oid' is already in the cache, raise. 
+        If 'oid' is already in the cache, raise.
         """
 
     def reify(to_reify):
@@ -536,7 +544,7 @@ class IPickleCache(Interface):
         o Any OID corresponding to a p-class will cause the corresponding
             p-class to be removed from the cache.
 
-        o For all other OIDs, ghostify the corrsponding object and 
+        o For all other OIDs, ghostify the corrsponding object and
             remove it from the ring.
         """
 

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -11,7 +11,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import sys
+
 
 from zope.interface import implementer
 
@@ -20,14 +20,13 @@ from persistent.interfaces import GHOST
 from persistent.interfaces import UPTODATE
 from persistent.interfaces import CHANGED
 from persistent.interfaces import STICKY
-from persistent.interfaces import OID_TYPE
+
 from persistent.interfaces import SERIAL_TYPE
 from persistent.timestamp import TimeStamp
 from persistent.timestamp import _ZERO
 from persistent._compat import copy_reg
 from persistent._compat import intern
 
-from . import ring
 
 _INITIAL_SERIAL = _ZERO
 
@@ -557,6 +556,31 @@ class Persistent(object):
         cache = getattr(jar, '_cache', None)
         if cache is not None:
             return cache.get(oid) is self
+
+    def __repr__(self):
+        oid = _OGA(self, '_Persistent__oid')
+        jar = _OGA(self, '_Persistent__jar')
+
+        oid_str = ''
+        jar_str = ''
+
+        if oid is not None:
+            try:
+                oid_str = ' oid %r' % (oid,)
+            except Exception as e:
+                oid_str = ' oid %r' % (e,)
+
+        if jar is not None:
+            try:
+                jar_str = ' in %r' % (jar,)
+            except Exception as e:
+                jar_str = ' in %r' % (e,)
+
+        return '<%s.%s object at 0x%x%s%s>' % (
+            type(self).__module__, type(self).__name__, id(self),
+            oid_str, jar_str
+        )
+
 
 def _estimated_size_in_24_bits(value):
     if value > 1073741696:

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -558,6 +558,14 @@ class Persistent(object):
             return cache.get(oid) is self
 
     def __repr__(self):
+        p_repr_str = ''
+        p_repr = getattr(type(self), '_p_repr', None)
+        if p_repr is not None:
+            try:
+                return p_repr(self)
+            except Exception as e:
+                p_repr_str = ' _p_repr %r' % (e,)
+
         oid = _OGA(self, '_Persistent__oid')
         jar = _OGA(self, '_Persistent__jar')
 
@@ -576,9 +584,9 @@ class Persistent(object):
             except Exception as e:
                 jar_str = ' in %r' % (e,)
 
-        return '<%s.%s object at 0x%x%s%s>' % (
+        return '<%s.%s object at 0x%x%s%s%s>' % (
             type(self).__module__, type(self).__name__, id(self),
-            oid_str, jar_str
+            oid_str, jar_str, p_repr_str
         )
 
 

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1789,6 +1789,27 @@ class _Persistent_Base(object):
             "<persistent.Persistent object at 0xdeadbeef oid Exception('oid repr failed')"
             " in Exception('jar repr failed')>")
 
+    def test_repr_no_oid_repr_jar_raises_baseexception(self):
+        p = self._makeOne()
+
+        class Jar(object):
+            def __repr__(self):
+                raise BaseException('jar repr failed')
+
+        p._p_jar = Jar()
+        with self.assertRaisesRegex(BaseException, 'jar repr failed'):
+            repr(p)
+
+    def test_repr_oid_raises_baseexception_no_jar(self):
+        p = self._makeOne()
+
+        class BadOID(bytes):
+            def __repr__(self):
+                raise BaseException("oid repr failed")
+        p._p_oid = BadOID(b'12345678')
+
+        with self.assertRaisesRegex(BaseException, 'oid repr failed'):
+            repr(p)
 
     def test_repr_oid_and_jar(self):
         p = self._makeOne()


### PR DESCRIPTION
As specified in #11. See the tests for what the output looks like; in the usual case it will be something like `"<persistent.Persistent object at 0xdeadbeef oid b'12345678' in <SomeJar>>"`

I would appreciate a thorough check of the C code, I'm not a C API expert.