### PR TITLE
Use unsigned constants for second arithmetic in C timestamp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 4.3.1 (unreleased)
 ------------------
 
+- Use unsigned constants when doing arithmetic on C timestamps,
+  possibly avoiding some overflow issues with some compilers or
+  compiler settings. See `issue 86
+  <https://github.com/zopefoundation/persistent/issues/86>`_.
+
 - Change the default representation of ``Persistent`` objects to
   include the representation of their OID and jar, if set. Also add
   the ability for subclasses to implement ``_p_repr()`` instead of

--- a/persistent/_timestamp.c
+++ b/persistent/_timestamp.c
@@ -185,8 +185,8 @@ TimeStamp_unpack(TimeStamp *self, TimeStampParts *p)
 {
     unsigned long v;
 
-    v = (self->data[0] * 16777216 + self->data[1] * 65536
-       + self->data[2] * 256 + self->data[3]);
+    v = (self->data[0] * 0x1000000 + self->data[1] * 0x10000
+       + self->data[2] * 0x100 + self->data[3]);
     p->y = v / 535680 + 1900;
     p->m = (v % 535680) / 44640 + 1;
     p->d = (v % 44640) / 1440 + 1;
@@ -198,8 +198,8 @@ TimeStamp_sec(TimeStamp *self)
 {
     unsigned int v;
 
-    v = (self->data[4] * 16777216 + self->data[5] * 65536
-     + self->data[6] * 256 + self->data[7]);
+    v = (self->data[4] * 0x1000000 + self->data[5] * 0x10000
+     + self->data[6] * 0x100 + self->data[7]);
     return SCONV * v;
 }
 
@@ -446,16 +446,16 @@ TimeStamp_FromDate(int year, int month, int day, int hour, int min,
     ts = (TimeStamp *)PyObject_New(TimeStamp, &TimeStamp_type);
     v = (((year - 1900) * 12 + month - 1) * 31 + day - 1);
     v = (v * 24 + hour) * 60 + min;
-    ts->data[0] = v / 16777216;
-    ts->data[1] = (v % 16777216) / 65536;
-    ts->data[2] = (v % 65536) / 256;
-    ts->data[3] = v % 256;
+    ts->data[0] = v / 0x1000000;
+    ts->data[1] = (v % 0x1000000) / 0x10000;
+    ts->data[2] = (v % 0x10000) / 0x100;
+    ts->data[3] = v % 0x100;
     sec /= SCONV;
     v = (unsigned int)sec;
-    ts->data[4] = v / 16777216;
-    ts->data[5] = (v % 16777216) / 65536;
-    ts->data[6] = (v % 65536) / 256;
-    ts->data[7] = v % 256;
+    ts->data[4] = v / 0x1000000;
+    ts->data[5] = (v % 0x1000000) / 0x10000;
+    ts->data[6] = (v % 0x10000) / 0x100;
+    ts->data[7] = v % 0x100;
 
     return (PyObject *)ts;
 }

--- a/persistent/_timestamp.c
+++ b/persistent/_timestamp.c
@@ -39,7 +39,7 @@ static char TimeStampModule_doc[] =
 #define TS_MINUTES_PER_YEAR (TS_MINUTES_PER_MONTH * TS_MONTHS_PER_YEAR)
 
 #define TS_PACK_UNSIGNED_INTO_BYTES(v, bytes) do { \
-    *(bytes) = v / 0x1000000;			   \
+    *(bytes) = v / 0x1000000;                      \
     *(bytes + 1) = (v % 0x1000000) / 0x10000;      \
     *(bytes + 2) = (v % 0x10000) / 0x100;          \
     *(bytes + 3) = v % 0x100;                      \
@@ -92,8 +92,6 @@ days_in_month(int year, int month)
 {
     return month_len[leap(year)][month];
 }
-
-
 
 static double
 TimeStamp_yad(int y)

--- a/persistent/timestamp.py
+++ b/persistent/timestamp.py
@@ -61,12 +61,12 @@ def _makeUTC(y, mo, d, h, mi, s):
 
 _EPOCH = _makeUTC(1970, 1, 1, 0, 0, 0)
 
-_SCONV = 60.0 / (1<<16) / (1<<16)
+_TS_SECOND_BYTES_BIAS = 60.0 / (1<<16) / (1<<16)
 
 def _makeRaw(year, month, day, hour, minute, second):
     a = (((year - 1900) * 12 + month - 1) * 31 + day - 1)
     a = (a * 24 + hour) * 60 + minute
-    b = int(second / _SCONV) # Don't round() this; the C version does simple truncation
+    b = int(second / _TS_SECOND_BYTES_BIAS) # Don't round() this; the C version does simple truncation
     return struct.pack('>II', a, b)
 
 def _parseRaw(octets):
@@ -76,7 +76,7 @@ def _parseRaw(octets):
     day = a // (60 * 24) % 31 + 1
     month = a // (60 * 24 * 31) % 12 + 1
     year = a // (60 * 24 * 31 * 12) + 1900
-    second = b * _SCONV
+    second = b * _TS_SECOND_BYTES_BIAS
     return (year, month, day, hour, minute, second)
 
 


### PR DESCRIPTION
This *might* fix #86? (*waves hands* by avoiding mixing signed and unsigned operations)

I personally find that it makes the data derivation/reconstruction more clear by making the powers-of-two factors more obvious. (The two smaller values were clear to me, but without punctuation it wasn't immediately obvious to me that 16777216 = 16,777,216 = 0x1000000 = 2^24.)

(Tested locally on 64-bit, relying on Appveyor CI for 32-bit tests.)