### PR TITLE
Make test pass when run with 'tox'

### DIFF
--- a/persistent/tests/test_docs.py
+++ b/persistent/tests/test_docs.py
@@ -33,12 +33,15 @@ import manuel.doctest
 import manuel.ignore
 import manuel.testing
 
-def test_suite():
-    here = os.path.dirname(__file__)
-    while not os.path.exists(os.path.join(here, 'setup.py')):
-        here = os.path.join(here, '..')
 
-    here = os.path.abspath(here)
+def test_suite():
+    here = os.path.dirname(os.path.abspath(__file__))
+    while not os.path.exists(os.path.join(here, 'setup.py')):
+        prev, here = here, os.path.dirname(here)
+        if here == prev:
+            # Let's avoid infinite loops at root
+            raise AssertionError('could not find my setup.py')
+
     docs = os.path.join(here, 'docs', 'api')
 
     files_to_test = (


### PR DESCRIPTION
I used to get failures like

    py27 runtests: commands[0] | zope-testrunner --test-path=.
    Test-module import failures:

    Module: persistent.tests.test_docs

    IOError: [Errno 2] No such file or directory: '/home/mg/src/zopefoundation/persistent/.tox/docs/api/cache.rst'

    Running zope.testrunner.layer.UnitTests tests:
      Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
      Ran 524 tests with 0 failures, 1 errors and 0 skipped in 0.249 seconds.
    Tearing down left over layers:
      Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.

    Test-modules with import problems:
      persistent.tests.test_docs
    ERROR: InvocationError for command '/home/mg/src/zopefoundation/persistent/.tox/py27/bin/zope-testrunner --test-path=.' (exited with code 1)

because adding a ../ at the end of the path is not the same as stripping off the last path component when symlinks are involved!

    $ cd .tox && ./py27/bin/python
    >>> >>> from persistent.tests.test_docs import __file__
    >>> __file__
    '/home/mg/src/zopefoundation/persistent/.tox/py27/local/lib/python2.7/site-packages/persistent/tests/test_docs.pyc'

.tox/py27/local/lib is a symlink to /home/mg/src/zopefoundation/persistent/.tox/py27/lib and so .tox/py27/local/lib/.. is pointing to .tox/py27, while os.path.abspath() thinks it's pointing to .tox/py27/local.

    >>> import os
    >>> here = os.path.dirname(__file__)
    >>> while not os.path.exists(os.path.join(here, 'setup.py')): here = os.path.join(here, '..')
    ...
    >>> here
    '/home/mg/src/zopefoundation/persistent/.tox/py27/local/lib/python2.7/site-packages/persistent/tests/../../../../../../..'
    >>> os.path.abspath(here)
    '/home/mg/src/zopefoundation/persistent/.tox'
    >>> os.path.exists(os.path.join(here, 'setup.py'))
    True
    >>> os.path.exists(os.path.join(os.path.abspath(here), 'setup.py'))
    False
    >>> os.path.exists(os.path.abspath(os.path.join(here, 'setup.py')))
    False