### PR TITLE
Include the module in the C repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@
 4.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the repr of the persistent objects to include the module name
+  when using the C extension. This matches the pure-Python behaviour
+  and the behaviour prior to 4.4.0. See `issue 92
+  <https://github.com/zopefoundation/persistent/issues/92>`_.
 
 
 4.4.2 (2018-08-28)

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -1460,6 +1460,11 @@ Per_repr(cPersistentObject *self)
     name = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
 
     if (!module || !name) {
+        /*
+          Some error retrieving __module__ or __name__. Ignore it, use the
+          C data.
+        */
+        PyErr_Clear();
         result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
                                       Py_TYPE(self)->tp_name, self,
                                       oid_str, jar_str, prepr_exc_str);

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -1423,6 +1423,8 @@ Per_repr(cPersistentObject *self)
     PyObject *prepr = NULL;
     PyObject *prepr_exc_str = NULL;
 
+    PyObject *module = NULL;
+    PyObject *name = NULL;
     PyObject *oid_str = NULL;
     PyObject *jar_str = NULL;
     PyObject *result = NULL;
@@ -1454,15 +1456,27 @@ Per_repr(cPersistentObject *self)
     if (!jar_str)
         goto cleanup;
 
-    result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
-                                  Py_TYPE(self)->tp_name, self,
-                                  oid_str, jar_str, prepr_exc_str);
+    module = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__module__");
+    name = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
+
+    if (!module || !name) {
+        result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
+                                      Py_TYPE(self)->tp_name, self,
+                                      oid_str, jar_str, prepr_exc_str);
+    }
+    else {
+        result = PyUnicode_FromFormat("<%S.%S object at %p%S%S%S>",
+                                      module, name, self,
+                                      oid_str, jar_str, prepr_exc_str);
+    }
 
 cleanup:
     Py_XDECREF(prepr);
     Py_XDECREF(prepr_exc_str);
     Py_XDECREF(oid_str);
     Py_XDECREF(jar_str);
+    Py_XDECREF(name);
+    Py_XDECREF(module);
 
     return result;
 }

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -585,7 +585,9 @@ class Persistent(object):
                 jar_str = ' in %r' % (e,)
 
         return '<%s.%s object at 0x%x%s%s%s>' % (
-            type(self).__module__, type(self).__name__, id(self),
+            # Match the C name for this exact class
+            type(self).__module__ if type(self) is not Persistent else 'persistent',
+            type(self).__name__, id(self),
             oid_str, jar_str, p_repr_str
         )
 

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1698,9 +1698,6 @@ class _Persistent_Base(object):
         self.assertEqual(candidate.set_by_new, 1)
 
     def _normalize_repr(self, r):
-        # Pure-python vs C
-        r = r.replace('persistent.persistence.Persistent', 'persistent.Persistent')
-        r = r.replace("persistent.tests.test_persistence.", '')
         # addresses
         r = re.sub(r'0x[0-9a-fA-F]*', '0xdeadbeef', r)
         # Python 3.7 removed the trailing , in exception reprs
@@ -1842,14 +1839,14 @@ class _Persistent_Base(object):
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef"
             " _p_repr Exception('_p_repr failed')>")
 
         p._p_oid = b'12345678'
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef oid b'12345678'"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef oid b'12345678'"
             " _p_repr Exception('_p_repr failed')>")
 
         class Jar(object):
@@ -1860,7 +1857,7 @@ class _Persistent_Base(object):
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef oid b'12345678'"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef oid b'12345678'"
             " in <SomeJar> _p_repr Exception('_p_repr failed')>")
 
     def test__p_repr_in_instance_ignored(self):
@@ -1869,7 +1866,8 @@ class _Persistent_Base(object):
         p = P()
         p._p_repr = lambda: "Instance"
         result = self._normalized_repr(p)
-        self.assertEqual(result, '<P object at 0xdeadbeef>')
+        self.assertEqual(result,
+                         '<persistent.tests.test_persistence.P object at 0xdeadbeef>')
 
     def test__p_repr_baseexception(self):
         class P(self._getTargetClass()):


### PR DESCRIPTION
Fix the repr of the persistent objects to include the module name when using the C extension. This matches the pure-Python behaviour and the behaviour prior to 4.4.0.

Do so by getting the `__module__` and `__name__` attributes of the type, just like the Python version. Credit to @mgedmin for the suggestion.

Fixes #92