### PR TITLE
Always format 8-byte oids as ints in hexadecimal.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
   and the behaviour prior to 4.4.0. See `issue 92
   <https://github.com/zopefoundation/persistent/issues/92>`_.
 
+- Change the repr of persistent objects to format the OID as in
+  integer in hexadecimal notation if it is an 8-byte byte string, as
+  ZODB does. This eliminates some issues in doctests. See `issue 95
+  <https://github.com/zopefoundation/persistent/pull/95>`_.
 
 4.4.2 (2018-08-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@
 4.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the repr of the persistent objects to include the module name
+  when using the C extension. This matches the pure-Python behaviour
+  and the behaviour prior to 4.4.0. See `issue 92
+  <https://github.com/zopefoundation/persistent/issues/92>`_.
 
 
 4.4.2 (2018-08-28)

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -16,7 +16,6 @@ static char cPersistence_doc_string[] =
   "\n"
   "$Id$\n";
 
-#include <stdint.h>
 #include "cPersistence.h"
 #include "structmember.h"
 
@@ -24,6 +23,16 @@ struct ccobject_head_struct
 {
     CACHE_HEAD
 };
+
+/*
+  The compiler on Windows used for Python 2.7 doesn't include
+  stdint.h.
+*/
+#if !defined(PY3K) && defined(_WIN32)
+typedef unsigned long long uint64_t;
+#else
+#include <stdint.h>
+#endif
 
 /* These two objects are initialized when the module is loaded */
 static PyObject *TimeStamp, *py_simple_new;

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -1460,6 +1460,11 @@ Per_repr(cPersistentObject *self)
     name = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
 
     if (!module || !name) {
+        /*
+          Some error retrieving __module__ or __name__. Ignore it, use the
+          C data.
+        */
+        PyErr_Clear();
         result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
                                       Py_TYPE(self)->tp_name, self,
                                       oid_str, jar_str, prepr_exc_str);

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -1423,6 +1423,8 @@ Per_repr(cPersistentObject *self)
     PyObject *prepr = NULL;
     PyObject *prepr_exc_str = NULL;
 
+    PyObject *module = NULL;
+    PyObject *name = NULL;
     PyObject *oid_str = NULL;
     PyObject *jar_str = NULL;
     PyObject *result = NULL;
@@ -1454,15 +1456,27 @@ Per_repr(cPersistentObject *self)
     if (!jar_str)
         goto cleanup;
 
-    result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
-                                  Py_TYPE(self)->tp_name, self,
-                                  oid_str, jar_str, prepr_exc_str);
+    module = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__module__");
+    name = PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
+
+    if (!module || !name) {
+        result = PyUnicode_FromFormat("<%s object at %p%S%S%S>",
+                                      Py_TYPE(self)->tp_name, self,
+                                      oid_str, jar_str, prepr_exc_str);
+    }
+    else {
+        result = PyUnicode_FromFormat("<%S.%S object at %p%S%S%S>",
+                                      module, name, self,
+                                      oid_str, jar_str, prepr_exc_str);
+    }
 
 cleanup:
     Py_XDECREF(prepr);
     Py_XDECREF(prepr_exc_str);
     Py_XDECREF(oid_str);
     Py_XDECREF(jar_str);
+    Py_XDECREF(name);
+    Py_XDECREF(module);
 
     return result;
 }

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -11,7 +11,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-
+import struct
 
 from zope.interface import implementer
 
@@ -51,6 +51,11 @@ SPECIAL_NAMES = ('__class__',
 # the standard names plus the slot names, allowing for just one
 # check in __getattribute__
 _SPECIAL_NAMES = set(SPECIAL_NAMES)
+
+# Represent 8-byte OIDs as hex integer, just like
+# ZODB does.
+_OID_STRUCT = struct.Struct('>Q')
+_OID_UNPACK = _OID_STRUCT.unpack
 
 @implementer(IPersistent)
 class Persistent(object):
@@ -574,7 +579,10 @@ class Persistent(object):
 
         if oid is not None:
             try:
-                oid_str = ' oid %r' % (oid,)
+                if isinstance(oid, bytes) and len(oid) == 8:
+                    oid_str = ' oid 0x%x' % (_OID_UNPACK(oid)[0],)
+                else:
+                    oid_str = ' oid %r' % (oid,)
             except Exception as e:
                 oid_str = ' oid %r' % (e,)
 

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -585,7 +585,9 @@ class Persistent(object):
                 jar_str = ' in %r' % (e,)
 
         return '<%s.%s object at 0x%x%s%s%s>' % (
-            type(self).__module__, type(self).__name__, id(self),
+            # Match the C name for this exact class
+            type(self).__module__ if type(self) is not Persistent else 'persistent',
+            type(self).__name__, id(self),
             oid_str, jar_str, p_repr_str
         )
 

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1698,9 +1698,6 @@ class _Persistent_Base(object):
         self.assertEqual(candidate.set_by_new, 1)
 
     def _normalize_repr(self, r):
-        # Pure-python vs C
-        r = r.replace('persistent.persistence.Persistent', 'persistent.Persistent')
-        r = r.replace("persistent.tests.test_persistence.", '')
         # addresses
         r = re.sub(r'0x[0-9a-fA-F]*', '0xdeadbeef', r)
         # Python 3.7 removed the trailing , in exception reprs
@@ -1842,14 +1839,14 @@ class _Persistent_Base(object):
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef"
             " _p_repr Exception('_p_repr failed')>")
 
         p._p_oid = b'12345678'
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef oid b'12345678'"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef oid b'12345678'"
             " _p_repr Exception('_p_repr failed')>")
 
         class Jar(object):
@@ -1860,7 +1857,7 @@ class _Persistent_Base(object):
         result = self._normalized_repr(p)
         self.assertEqual(
             result,
-            "<P object at 0xdeadbeef oid b'12345678'"
+            "<persistent.tests.test_persistence.P object at 0xdeadbeef oid b'12345678'"
             " in <SomeJar> _p_repr Exception('_p_repr failed')>")
 
     def test__p_repr_in_instance_ignored(self):
@@ -1869,7 +1866,8 @@ class _Persistent_Base(object):
         p = P()
         p._p_repr = lambda: "Instance"
         result = self._normalized_repr(p)
-        self.assertEqual(result, '<P object at 0xdeadbeef>')
+        self.assertEqual(result,
+                         '<persistent.tests.test_persistence.P object at 0xdeadbeef>')
 
     def test__p_repr_baseexception(self):
         class P(self._getTargetClass()):

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1740,6 +1740,21 @@ class _Persistent_Base(object):
             result,
             "<persistent.Persistent object at 0xdeadbeef oid " + self._HEX_OID + ">")
 
+    def test_64bit_oid(self):
+        import struct
+        p = self._makeOne()
+        oid_value = 2 << 62
+        self.assertEqual(oid_value.bit_length(), 64)
+        oid = struct.pack(">Q", oid_value)
+        self.assertEqual(oid, b'\x80\x00\x00\x00\x00\x00\x00\x00')
+
+        p._p_oid = oid
+        result = self._normalized_repr(p)
+        self.assertEqual(
+            result,
+            '<persistent.Persistent object at 0xdeadbeef oid 0x8000000000000000>'
+        )
+
     def test_repr_no_oid_repr_jar_raises_exception(self):
         p = self._makeOne()
 


### PR DESCRIPTION

Fixes #95

Built on #97 as they touch the same code.