### PR TITLE
Exclude the 'terryfy' directory from wheels and sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+prune terryfy
+
 include *.txt
 include *.rst
 include *.sh
@@ -14,6 +16,7 @@ global-exclude coverage.xml
 
 prune docs/_build
 prune persistent/__pycache__
+
 
 include .coveragerc
 include .travis.yml

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,9 @@ setup(name='persistent',
       url="https://github.com/zopefoundation/persistent/",
       license="ZPL 2.1",
       platforms=["any"],
-      packages=find_packages(),
+      # Make sure we don't get 'terryfy' included in wheels
+      # created on macOS CI
+      packages=find_packages(include=("persistent",)),
       include_package_data=True,
       zip_safe=False,
       ext_modules=ext_modules,


### PR DESCRIPTION
Fixes #99 

`bdist_wheel` isn't guided by the MANIFEST, only sdists are. So we have to specify what packages to include in setup.py, which is what guides bdist_wheel.