### PR TITLE
Fully test the C implementation of the PickleCache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,20 @@
 ``persistent`` Changelog
 ========================
 
-4.4.4 (unreleased)
+4.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fully test the C implementation of the PickleCache, and fix
+  discrepancies between it and the Python implementation:
+
+  - The C implementation now raises ``ValueError`` instead of
+    ``AssertionError`` for certain types of bad inputs.
+  - The Python implementation uses the C wording for error messages.
+  - The C implementation properly implements ``IPickleCache``; methods
+    unique to the Python implementation were moved to
+    ``IExtendedPickleCache``.
+  - The Python implementation raises ``AttributeError`` if a
+    persistent class doesn't have a ``p_jar`` attribute.
 
 
 4.4.3 (2018-10-22)

--- a/persistent/__init__.py
+++ b/persistent/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
 ]
 from persistent._compat import PURE_PYTHON
 from persistent.interfaces import IPersistent
+from persistent.interfaces import IPickleCache
 
 import persistent.timestamp as TimeStamp
 
@@ -48,6 +49,7 @@ else:
     # Note that the Python version already does this.
     from zope.interface import classImplements
     classImplements(_cPersistence.Persistent, IPersistent)
+    classImplements(_cPickleCache.PickleCache, IPickleCache)
 
 
 _persistence = pyPersistence if PURE_PYTHON or _cPersistence is None else _cPersistence

--- a/persistent/cPickleCache.c
+++ b/persistent/cPickleCache.c
@@ -727,7 +727,7 @@ cc_new_ghost(ccobject *self, PyObject *args)
     Py_DECREF(tmp);
     if (tmp != Py_None)
     {
-        PyErr_SetString(PyExc_AssertionError,
+        PyErr_SetString(PyExc_ValueError,
                         "New ghost object must not have an oid");
         return NULL;
     }
@@ -739,7 +739,7 @@ cc_new_ghost(ccobject *self, PyObject *args)
     Py_DECREF(tmp);
     if (tmp != Py_None)
     {
-        PyErr_SetString(PyExc_AssertionError,
+        PyErr_SetString(PyExc_ValueError,
                         "New ghost object must not have a jar");
         return NULL;
     }
@@ -748,7 +748,7 @@ cc_new_ghost(ccobject *self, PyObject *args)
     if (tmp)
     {
         Py_DECREF(tmp);
-        PyErr_SetString(PyExc_AssertionError,
+        PyErr_SetString(PyExc_ValueError,
                         "The given oid is already in the cache");
         return NULL;
     }

--- a/persistent/interfaces.py
+++ b/persistent/interfaces.py
@@ -439,12 +439,6 @@ class IPickleCache(Interface):
         o Return 'default' if not found.
         """
 
-    def mru(oid):
-        """ Move the element corresonding to 'oid' to the head.
-
-        o Raise KeyError if no element is found.
-        """
-
     def __len__():
         """ -> the number of OIDs in the cache.
         """
@@ -516,23 +510,6 @@ class IPickleCache(Interface):
         If 'oid' is already in the cache, raise.
         """
 
-    def reify(to_reify):
-        """ Reify the indicated objects.
-
-        o If 'to_reify' is a string, treat it as an OID.
-
-        o Otherwise, iterate over it as a sequence of OIDs.
-
-        o For each OID, if present in 'data' and in GHOST state:
-
-            o Call '_p_activate' on the object.
-
-            o Add it to the ring.
-
-        o If any OID is present but not in GHOST state, skip it.
-
-        o Raise KeyErrory if any OID is not present.
-        """
 
     def invalidate(to_invalidate):
         """ Invalidate the indicated objects.
@@ -566,3 +543,33 @@ class IPickleCache(Interface):
                                         'ringlen?')
     cache_data = Attribute("Property:  copy of our 'data' dict")
     cache_klass_count = Attribute("Property: len of 'persistent_classes'")
+
+
+class IExtendedPickleCache(IPickleCache):
+    """
+    Extra operations for a pickle cache.
+    """
+
+    def reify(to_reify):
+        """ Reify the indicated objects.
+
+        o If 'to_reify' is a string, treat it as an OID.
+
+        o Otherwise, iterate over it as a sequence of OIDs.
+
+        o For each OID, if present in 'data' and in GHOST state:
+
+            o Call '_p_activate' on the object.
+
+            o Add it to the ring.
+
+        o If any OID is present but not in GHOST state, skip it.
+
+        o Raise KeyErrory if any OID is not present.
+        """
+
+    def mru(oid):
+        """ Move the element corresonding to 'oid' to the head.
+
+        o Raise KeyError if no element is found.
+        """


### PR DESCRIPTION
Fix discrepancies between it and the Python implementation:

  - The C implementation now raises ``ValueError`` instead of ``AssertionError`` for certain types of bad inputs.
  - The Python implementation uses the C wording for error messages.
  - The C implementation properly implements ``IPickleCache``; methods  unique to the Python implementation were moved to ``IExtendedPickleCache``.
  - The Python implementation raises ``AttributeError`` if a  persistent class doesn't have a ``p_jar`` attribute.

Fixes #102