### PR TITLE
Use Py_ssize_t for length arguments of PyArg_ParseTuple

### DIFF
--- a/persistent/_timestamp.c
+++ b/persistent/_timestamp.c
@@ -12,6 +12,7 @@
 
  ****************************************************************************/
 
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "bytesobject.h"
 #include <time.h>
@@ -533,7 +534,8 @@ PyObject *
 TimeStamp_TimeStamp(PyObject *obj, PyObject *args)
 {
     char *buf = NULL;
-    int len = 0, y, mo, d, h = 0, m = 0;
+    Py_ssize_t len = 0;
+    int y, mo, d, h = 0, m = 0;
     double sec = 0;
 
 #ifdef PY3K

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -16,6 +16,7 @@ static char cPersistence_doc_string[] =
   "\n"
   "$Id$\n";
 
+#define PY_SSIZE_T_CLEAN
 #include "cPersistence.h"
 #include "structmember.h"
 
@@ -1268,9 +1269,9 @@ Per_get_mtime(cPersistentObject *self)
     }
 
 #ifdef PY3K
-    t = PyObject_CallFunction(TimeStamp, "y#", self->serial, 8);
+    t = PyObject_CallFunction(TimeStamp, "y#", self->serial, (Py_ssize_t)8);
 #else
-    t = PyObject_CallFunction(TimeStamp, "s#", self->serial, 8);
+    t = PyObject_CallFunction(TimeStamp, "s#", self->serial, (Py_ssize_t)8);
 #endif
     if (!t)
     {


### PR DESCRIPTION
This API was introduced in Python 2.5 and the old one (using ints) has been deprecated since Python 3.8.

Fixes #108.

Somebody who actually knows the Python C API please review this, because I just pretend I know C.