### PR TITLE
FIX: Clearing a persistent list does not mark it as changed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,10 @@ script:
   # coverage makes PyPy run about 3x slower, but the tests only take
   # .4s to begin with (the whole process takes about 1.5), so that's
   # still only 4.5s, which is maneagable.
-  - coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress
+  - python -m coverage run -m zope.testrunner --test-path=. --auto-color --auto-progress
 
 after_success:
-  - coveralls
+  - python -m coveralls
   - |
     if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then
       pip install twine

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@
 4.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fixed ``PersistentList`` to mark itself as changed after calling
+  ``clear``. See `PR 115 <https://github.com/zopefoundation/persistent/pull/115/>`_.
 
 4.5.1 (2019-11-06)
 ------------------
@@ -13,8 +13,6 @@
 - Add support for Python 3.8.
 
 - Update documentation to Python 3.
-
-- Fixed ``PersistentList``s not marked as changed after calling ``clear``.
 
 
 4.5.0 (2019-05-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 
 - Update documentation to Python 3.
 
+- Fixed ``PersistentList``s not marked as changed after calling ``clear``.
+
 
 4.5.0 (2019-05-09)
 ------------------

--- a/persistent/list.py
+++ b/persistent/list.py
@@ -15,16 +15,24 @@
 """Python implementation of persistent list.
 
 $Id$"""
-
+import sys
 import persistent
 from persistent._compat import UserList
 from persistent._compat import PYTHON2
+
+# The slice object you get when you write list[:]
+_SLICE_ALL = slice(None, None, None)
 
 class PersistentList(UserList, persistent.Persistent):
     """A persistent wrapper for list objects.
 
     Mutating instances of this class will cause them to be marked
     as changed and automatically persisted.
+
+    .. versionchanged:: 4.5.2
+       Using the `clear` method, or writing ``del inst[:]`` now only
+       results in marking the instance as changed if it actually removed
+       items.
     """
     __super_setitem = UserList.__setitem__
     __super_delitem = UserList.__delitem__
@@ -37,14 +45,23 @@ class PersistentList(UserList, persistent.Persistent):
     __super_reverse = UserList.reverse
     __super_sort = UserList.sort
     __super_extend = UserList.extend
+    __super_clear = (
+        UserList.clear
+        if hasattr(UserList, 'clear')
+        else lambda inst: inst.__delitem__(slice(None, None, None))
+    )
 
     def __setitem__(self, i, item):
         self.__super_setitem(i, item)
         self._p_changed = 1
 
     def __delitem__(self, i):
+        # If they write del list[:] but we're empty,
+        # no need to mark us changed.
+        needs_changed = i != _SLICE_ALL or bool(self)
         self.__super_delitem(i)
-        self._p_changed = 1
+        if needs_changed:
+            self._p_changed = 1
 
     if PYTHON2:  # pragma: no cover
         __super_setslice = UserList.__setslice__
@@ -55,8 +72,11 @@ class PersistentList(UserList, persistent.Persistent):
             self._p_changed = 1
 
         def __delslice__(self, i, j):
+            # For list[:], i and j become 0 and sys.maxint
+            needs_changed = i == 0 and j == sys.maxint and bool(self)
             self.__super_delslice(i, j)
-            self._p_changed = 1
+            if needs_changed:
+                self._p_changed = 1
 
     def __iadd__(self, other):
         L = self.__super_iadd(other)
@@ -72,11 +92,17 @@ class PersistentList(UserList, persistent.Persistent):
         self.__super_append(item)
         self._p_changed = 1
 
-    if not PYTHON2:
-        __super_clear = UserList.clear
+    def clear(self):
+        """
+        Remove all items from the list.
 
-        def clear(self):
-            self.__super_clear()
+        .. versionchanged:: 4.5.2
+           Now marks the list as changed, and is available
+           on both Python 2 and Python 3.
+        """
+        needs_changed = bool(self)
+        self.__super_clear()
+        if needs_changed:
             self._p_changed = 1
 
     def insert(self, i, item):

--- a/persistent/list.py
+++ b/persistent/list.py
@@ -72,6 +72,13 @@ class PersistentList(UserList, persistent.Persistent):
         self.__super_append(item)
         self._p_changed = 1
 
+    if not PYTHON2:
+        __super_clear = UserList.clear
+
+        def clear(self):
+            self.__super_clear()
+            self._p_changed = 1
+
     def insert(self, i, item):
         self.__super_insert(i, item)
         self._p_changed = 1

--- a/persistent/mapping.py
+++ b/persistent/mapping.py
@@ -92,7 +92,7 @@ class PersistentMapping(IterableUserDict, persistent.Persistent):
 
     @default
     def data(self):
-        # We don't want to cause a write on read, so wer're careful not to
+        # We don't want to cause a write on read, so we're careful not to
         # do anything that would cause us to become marked as changed, however,
         # if we're modified, then the saved record will have data, not
         # _container.

--- a/persistent/tests/test_list.py
+++ b/persistent/tests/test_list.py
@@ -268,12 +268,21 @@ class TestPList(unittest.TestCase):
         self.assertEqual(inst, [1, 2, 3])
         self.assertTrue(inst._p_changed)
 
-    def test_delslice(self):
+    def test_delslice_nonempty(self):
         inst = self._makeOne([1, 2, 3])
         self.assertFalse(inst._p_changed)
         self.assertEqual(inst, [1, 2, 3])
         del inst[:]
+        self.assertEqual(inst, [])
         self.assertTrue(inst._p_changed)
+
+    def test_delslice_empty(self):
+        inst = self._makeOne([])
+        self.assertFalse(inst._p_changed)
+        self.assertEqual(inst, [])
+        del inst[:]
+        self.assertEqual(inst, [])
+        self.assertFalse(inst._p_changed)
 
     def test_iadd(self):
         inst = self._makeOne()
@@ -303,14 +312,19 @@ class TestPList(unittest.TestCase):
         self.assertEqual(inst, [1])
         self.assertTrue(inst._p_changed)
 
-    def test_clear(self):
-        inst = self._makeOne([1])
-        if not hasattr(inst, 'clear'):
-            raise unittest.SkipTest("PersistentList has no clear() method")
+    def test_clear_nonempty(self):
+        inst = self._makeOne([1, 2, 3, 4])
         self.assertFalse(inst._p_changed)
         inst.clear()
         self.assertEqual(inst, [])
         self.assertTrue(inst._p_changed)
+
+    def test_clear_empty(self):
+        inst = self._makeOne([])
+        self.assertFalse(inst._p_changed)
+        inst.clear()
+        self.assertEqual(inst, [])
+        self.assertFalse(inst._p_changed)
 
     def test_insert(self):
         inst = self._makeOne()

--- a/persistent/tests/test_list.py
+++ b/persistent/tests/test_list.py
@@ -303,6 +303,15 @@ class TestPList(unittest.TestCase):
         self.assertEqual(inst, [1])
         self.assertTrue(inst._p_changed)
 
+    def test_clear(self):
+        inst = self._makeOne([1])
+        if not hasattr(inst, 'clear'):
+            raise unittest.SkipTest("PersistentList has no clear() method")
+        self.assertFalse(inst._p_changed)
+        inst.clear()
+        self.assertEqual(inst, [])
+        self.assertTrue(inst._p_changed)
+
     def test_insert(self):
         inst = self._makeOne()
         self.assertFalse(inst._p_changed)


### PR DESCRIPTION
The inherited `clear()` method in UserList can modify the `PersistentList` without causing the object to be marked as changed. This patch causes the `clear()` method to mark the object as changed.