### PR TITLE
Enable Python 3.8 on Appveyer and also for manylinux builds

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -7,7 +7,8 @@ for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \
-       [[ "${PYBIN}" == *"cp37"* ]]; then
+       [[ "${PYBIN}" == *"cp37"* ]] || \
+       [[ "${PYBIN}" == *"cp38"* ]]; then
         "${PYBIN}/pip" install -U pip setuptools wheel cffi
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,18 @@ environment:
     - python: 36-x64
     - python: 37
     - python: 37-x64
+    - python: 38
+    - python: 38-x64
+
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - ps: |
+      $env:PYTHON = "C:\\Python${env:PYTHON}"
+      if (-not (Test-Path $env:PYTHON)) {
+        curl -o install_python.ps1 https://raw.githubusercontent.com/matthew-brett/multibuild/11a389d78892cf90addac8f69433d5e22bfa422a/install_python.ps1
+        .\install_python.ps1
+      }
+  - ps: if (-not (Test-Path $env:PYTHON)) { throw "No $env:PYTHON" }
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
   - python -m pip install -U pip setuptools wheel cffi
   - pip install -e .[test]


### PR DESCRIPTION
Since 3.8 is not available on Appveyor yet, use a script to install it.

Meant to fix #117 eventually.