### PR TITLE
terrif now supports py3.8 builds on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ jobs:
       os: osx
       language: generic
       env: TERRYFY_PYTHON='macpython 3.7.0'
+    - name: Python 3.8 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.8.0'
 
 before_install:
   - |


### PR DESCRIPTION
Terrify now supports building py3.8 on mac os.