### PR TITLE
Use Python 3.6.2 on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,9 @@ jobs:
       os: osx
       language: generic
       # NB: 3.6.0 causes https://github.com/nedbat/coveragepy/issues/703
-      env: TERRYFY_PYTHON='macpython 3.6.1'
+      # NB: 3.6.1 had that ABI regression (fixed in 3.6.2) and would be a bad
+      # version to use
+      env: TERRYFY_PYTHON='macpython 3.6.2'
     - name: Python 3.7 wheels for MacOS
       os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ jobs:
     - name: Python 3.6 wheels for MacOS
       os: osx
       language: generic
-      env: TERRYFY_PYTHON='macpython 3.6.0'
+      # NB: 3.6.0 causes https://github.com/nedbat/coveragepy/issues/703
+      env: TERRYFY_PYTHON='macpython 3.6.1'
     - name: Python 3.7 wheels for MacOS
       os: osx
       language: generic


### PR DESCRIPTION
Our Python 3.6 builds on MacOS started failing with a
> Couldn't use data file '/Users/travis/build/zopefoundation/persistent/.coverage': Safety level
may not be changed inside a transaction

error from `coverage run`, after the test suite is done and it's time to collate and store coverage data.  This is probably caused by a new release of coverage.py (5.0.3; the last successfull built had coverage 4.5.4) that uses sqlite for .coverage and is reported upstream as https://github.com/nedbat/coveragepy/issues/703.

Other platforms and other Python versions do not have this problem.  Other platforms use a newer Python 3.6.x dot release, while MacOS is pinned to 3.6.0.

This PR is an experiment to see if a different Python 3.6.x dot release helps.  Turns out it does!

We have a few other zopefoundation packages using Python 3.6.1 for MacOS wheel building:
- BTrees
- zodbpickle
- zope.index

Whereas these are pinned to 3.6.0 (and I wonder if we're about to see similar failures):
- zope.container
- zope.hookable
- zope.i18nmessageid
- zope.interface
- zope.proxy
- zope.security

I'd appreciate additional attention from @jamadden and @fgregg, since IIRC you are familiar with Mac OS subtleties.  (Wasn't Python 3.6.1 the release that broke ABI compatibility with 3.6.0, and 3.6.2 again broke ABI compatibility with 3.6.1 to restore compatibility with 3.6.0?  Should we use 3.6.2 for wheel building instead of 3.6.1?)

I don't use Macs myself, but I care about Travis builds on git master being green.