### PR TITLE
Fix PersistentDict.update to accept keyword arguments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,20 @@
 4.5.2 (unreleased)
 ------------------
 
-- Fixed ``PersistentList`` to mark itself as changed after calling
+- Fix ``PersistentList`` to mark itself as changed after calling
   ``clear``. See `PR 115 <https://github.com/zopefoundation/persistent/pull/115/>`_.
+
+- Fix ``PersistentMapping.update`` to accept keyword arguments like
+  the native ``UserDict``. Previously, most uses of keyword arguments
+  resulted in ``TypeError``; in the undocumented and extremely
+  unlikely event of a single keyword argument called ``b`` that
+  happens to be a dictionary, the behaviour will change. Also adjust
+  the signatures of ``setdefault`` and ``pop`` to match the native
+  version.
+
+- Fix ``PersistentList.clear``, ``PersistentMapping.clear`` and
+  ``PersistentMapping.popitem`` to no longer mark the object as
+  changed if it was empty.
 
 4.5.1 (2019-11-06)
 ------------------

--- a/persistent/tests/test_list.py
+++ b/persistent/tests/test_list.py
@@ -16,6 +16,8 @@
 
 import unittest
 
+from persistent.tests.utils import TrivialJar
+
 l0 = []
 l1 = [0]
 l2 = [0, 1]
@@ -30,6 +32,7 @@ class OtherList:
     def __getitem__(self, i):
         return self.__data[i]
 
+
 class TestPList(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -37,10 +40,7 @@ class TestPList(unittest.TestCase):
         return PersistentList
 
     def _makeJar(self):
-        class Jar(object):
-            def register(self, obj):
-                "no-op"
-        return Jar()
+        return TrivialJar()
 
     def _makeOne(self, *args):
         inst = self._getTargetClass()(*args)

--- a/persistent/tests/utils.py
+++ b/persistent/tests/utils.py
@@ -1,4 +1,13 @@
 
+class TrivialJar(object):
+    """
+    Jar that only supports registering objects so ``_p_changed``
+    can be tested.
+    """
+
+    def register(self, ob):
+        """Does nothing"""
+
 class ResettingJar(object):
     """Testing stub for _p_jar attribute.
     """


### PR DESCRIPTION
Like the native ``UserDict``. Previously, most uses of keyword arguments resulted in ``TypeError``; in the undocumented and extremely unlikely event of a single keyword argument called ``b`` that happens to be a dictionary, the behaviour will change. Also adjust
the signatures of ``setdefault`` and ``pop`` to match the native version.

Also optimize `clear` and `popitem` to not mark the object as changed unnecessarily.

Fixes #126 