### PR TITLE
Fix issue 124

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@
   ``PersistentMapping.popitem`` to no longer mark the object as
   changed if it was empty.
 
-- Add support for Python 3.9a3+ by updating references to deprecated
-  and moved functions. See `issue 124 <https://github.com/zopefoundation/persistent/issues/124>`_.
+- Add support for Python 3.9a3+.
+  See `issue 124 <https://github.com/zopefoundation/persistent/issues/124>`_.
 
 
 4.5.1 (2019-11-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@
   ``PersistentMapping.popitem`` to no longer mark the object as
   changed if it was empty.
 
+- Add support for Python 3.9a3+ by updating references to deprecated
+  and moved functions. See `issue 124 <https://github.com/zopefoundation/persistent/issues/124>`_.
+
+
 4.5.1 (2019-11-06)
 ------------------
 

--- a/persistent/cPersistence.c
+++ b/persistent/cPersistence.c
@@ -290,7 +290,7 @@ changed(cPersistentObject *self)
         }
         Py_INCREF(self);
         PyTuple_SET_ITEM(arg, 0, (PyObject *)self);
-        result = PyEval_CallObject(meth, arg);
+        result = PyObject_CallObject(meth, arg);
         Py_DECREF(arg);
         Py_DECREF(meth);
         if (result == NULL)

--- a/persistent/cPickleCache.c
+++ b/persistent/cPickleCache.c
@@ -631,7 +631,7 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
     /* This is called from the deallocation function after the
         interpreter has untracked the reference.  Track it again.
 	Starting in 3.9, these functions aren't available with the
-	stable (limited) API.
+	stable (limited) API and are only defined when they do something.
 
 	XXX: Why? Why not simply INCREF it? The CPython documentation
 	explicitly states these functions are for internal use only.
@@ -640,8 +640,13 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
     /* Don't increment total refcount as a result of the
         shenanigans played in this function.  The _Py_NewReference()
         call above creates artificial references to v.
+
+	This variable was was completely removed in 3.9 unless
+	Py_REF_DEBUG is also defined.
     */
+#if PY_VERSION_HEX < 0x03090000 || defined(Py_REF_DEBUG)
     _Py_RefTotal--;
+#endif
     assert(dead_pers_obj->ob_type);
 #else
     Py_INCREF(dead_pers_obj);

--- a/persistent/cPickleCache.c
+++ b/persistent/cPickleCache.c
@@ -614,54 +614,61 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
         not release the global interpreter lock until this is
         complete. */
 
-    PyObject *v;
+    PyObject *dead_pers_obj;
 
     /* If the cache has been cleared by GC, data will be NULL. */
     if (!self->data)
         return;
 
-    v = PyDict_GetItem(self->data, oid);
-    assert(v);
-    assert(v->ob_refcnt == 0);
+    dead_pers_obj = PyDict_GetItem(self->data, oid);
+    assert(dead_pers_obj);
+    assert(dead_pers_obj->ob_refcnt == 0);
     /* Need to be very hairy here because a dictionary is about
         to decref an already deleted object.
     */
 
-#ifdef Py_TRACE_REFS
+#if defined(Py_TRACE_REFS) && !defined(Py_LIMITED_API)
     /* This is called from the deallocation function after the
         interpreter has untracked the reference.  Track it again.
+	Starting in 3.9, these functions aren't available with the
+	stable (limited) API.
+
+	XXX: Why? Why not simply INCREF it? The CPython documentation
+	explicitly states these functions are for internal use only.
     */
-    _Py_NewReference(v);
+    _Py_NewReference(dead_pers_obj);
     /* Don't increment total refcount as a result of the
         shenanigans played in this function.  The _Py_NewReference()
         call above creates artificial references to v.
     */
     _Py_RefTotal--;
-    assert(v->ob_type);
+    assert(dead_pers_obj->ob_type);
 #else
-    Py_INCREF(v);
+    Py_INCREF(dead_pers_obj);
 #endif
-    assert(v->ob_refcnt == 1);
+    assert(dead_pers_obj->ob_refcnt == 1);
     /* Incremement the refcount again, because delitem is going to
-        DECREF it.  If it's refcount reached zero again, we'd call back to
+        DECREF it.  If its refcount reached zero again, we'd call back to
         the dealloc function that called us.
     */
-    Py_INCREF(v);
+    Py_INCREF(dead_pers_obj);
 
     /* TODO:  Should we call _Py_ForgetReference() on error exit? */
     if (PyDict_DelItem(self->data, oid) < 0)
         return;
-    Py_DECREF((ccobject *)((cPersistentObject *)v)->cache);
-    ((cPersistentObject *)v)->cache = NULL;
+    Py_DECREF((ccobject *)((cPersistentObject *)dead_pers_obj)->cache);
+    ((cPersistentObject *)dead_pers_obj)->cache = NULL;
 
-    assert(v->ob_refcnt == 1);
+    assert(dead_pers_obj->ob_refcnt == 1);
 
-    /* Undo the temporary resurrection.
-        Don't DECREF the object, because this function is called from
+    /* Don't DECREF the object, because this function is called from
         the object's dealloc function. If the refcnt reaches zero, it
         will all be invoked recursively.
     */
-    _Py_ForgetReference(v);
+#if defined(Py_TRACE_REFS) && !defined(Py_LIMITED_API)
+    /* But we need to undo the temporary resurrection. */
+    _Py_ForgetReference(dead_pers_obj);
+#endif
 }
 
 static PyObject *

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,12 @@ if is_pypy:
     ext_modules = []
     headers = []
 else:
+    define_macros = (
+        # We currently use macros like PyBytes_AS_STRING
+        # and internal functions like _PyObject_GetDictPtr
+        # that make it impossible to use the stable (limited) API.
+        # ('Py_LIMITED_API', '0x03050000'),
+    )
     ext_modules = [
         Extension(
             name='persistent.cPersistence',
@@ -55,7 +61,8 @@ else:
                 'persistent/cPersistence.h',
                 'persistent/ring.h',
                 'persistent/ring.c',
-            ]
+            ],
+            define_macros=list(define_macros),
         ),
         Extension(
             name='persistent.cPickleCache',
@@ -67,13 +74,15 @@ else:
                 'persistent/cPersistence.h',
                 'persistent/ring.h',
                 'persistent/ring.c',
-            ]
+            ],
+            define_macros=list(define_macros),
         ),
         Extension(
             name='persistent._timestamp',
             sources=[
                 'persistent/_timestamp.c',
             ],
+            define_macros=list(define_macros),
         ),
     ]
     headers = [


### PR DESCRIPTION
There are three commits showing the iterations I went through.

- The first commit adds the necessary preprocessor magic to make the extension build and run on 3.9.0a3+.
- The second commit adds more preprocessor magic to make it build and run on 3.9.0a3 if `Py_TRACE_REFS` is actually defined.
- The third commit removes all usage of those internal functions entirely, after I verified that everything still worked on the `Py_TRACE_REFS` build.

Rationale to remove usage of the internal functions:

- They're documented specifically as only to be used by the core interpreter.
- The nesting of conditions to make them work was pretty ugly.
- Especially since the core logic of the function is already "hairy."
- It was not at all clear to me that they were actually doing the right thing anymore given the way the interpreter has evolved (e.g., with the separation of `Py_REF_DEBUG` and `Py_TRACE_REFS`); it's possible they could do more harm than good (I didn't observe any issues with just `Py_TRACE_REFS`, but I didn't test any more combos of settings)
- I *think* they were there to assist in debugging. But this function hasn't changed substantially in the history of this repository (9 years), so maybe it's debugged.

Fixes #124 