### PR TITLE
Python3: Stop using undocumented PyLong_AS_LONG.

### DIFF
--- a/persistent/_compat.h
+++ b/persistent/_compat.h
@@ -31,7 +31,7 @@
 
 #define INT_FROM_LONG(x) PyLong_FromLong(x)
 #define INT_CHECK(x) PyLong_Check(x)
-#define INT_AS_LONG(x) PyLong_AS_LONG(x)
+#define INT_AS_LONG(x) PyLong_AsLong(x)
 #define CAPI_CAPSULE_NAME "persistent.cPersistence.CAPI"
 
 #else


### PR DESCRIPTION
Fixes #125

Because it was just an alias for the documented API, there should be no repercussions. The exception (and the reason for this issue in the first place) is if something both includes 'cPersistence.h' and also defines their own INT_AS_LONG macro. If the definitions differ, the compiler might now emit a warning. I [saw that in BTrees]( https://github.com/zopefoundation/BTrees/pull/122/files#diff-277c29c35c8feb60719e5ec94a3fe72e)