### PR TITLE
Add the ability to force use of C extensions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ env:
     - TWINE_USERNAME: zope.wheelbuilder
     # this sets $PYPIPASSWORD
     - secure: "NTWzDr5p8KRPNt+sniTot7csbzC87rzir/XfLtENE0GpQ49FlKw3lBhsDqAPoD8Ea5lwiHXmC/C/ci1UZhFvVEkAoQ2qJlMRnhqUdRJSrqcitmRt0fT6mLaTd+Lr+DxKlBxpssobrEm2G42V/G1s0Ggym04OqF8T+s6MF5ywgJM="
+    # We want to require the C extensions to build and function
+    # everywhere (except where we specifically opt-out, currently just
+    # PyPy, where they build but don't quite work).
+    - PURE_PYTHON: 0
+
 
 python:
   - 2.7
@@ -12,11 +17,15 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - pypy
-  - pypy3
 
 jobs:
   include:
+    # Don't test C extensions on PyPy.
+    - python: pypy
+      env: PURE_PYTHON=1
+
+    - python: pypy3
+      env: PURE_PYTHON=1
 
     # Special Linux builds
     - name: "Python: 2.7, pure (no C extensions)"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@
   broken prior to Python 3.7.4.
 
 - Update the handling of the ``PURE_PYTHON`` environment variable.
-  Now, a value of 0 requires the C extensions to be used; any other
-  value prevents the extensions from being used. Also, all C
+  Now, a value of "0" requires that the C extensions be used; any other
+  non-empty value prevents the extensions from being used. Also, all C
   extensions are required together or none of them will be used. This
   prevents strange errors that arise from a mismatch of Python and C
   implementations. See `issue 131 <https://github.com/zopefoundation/persistent/issues/131>`_.
@@ -22,7 +22,8 @@
   the pure-Python implementations have changed.
 
 - Fix ``PersistentList`` to mark itself as changed after calling
-  ``clear``. See `PR 115 <https://github.com/zopefoundation/persistent/pull/115/>`_.
+  ``clear`` (if needed). See `PR 115
+  <https://github.com/zopefoundation/persistent/pull/115/>`_.
 
 - Fix ``PersistentMapping.update`` to accept keyword arguments like
   the native ``UserDict``. Previously, most uses of keyword arguments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 ``persistent`` Changelog
 ========================
 
-4.5.2 (unreleased)
+4.6.0 (unreleased)
 ------------------
 
 - Fix slicing of ``PersistentList`` to always return instances of the
@@ -10,6 +10,16 @@
 - Fix copying  of ``PersistentList`` and ``PersistentMapping`` using
   ``copy.copy`` to also copy the underlying data object. This was
   broken prior to Python 3.7.4.
+
+- Update the handling of the ``PURE_PYTHON`` environment variable.
+  Now, a value of 0 requires the C extensions to be used; any other
+  value prevents the extensions from being used. Also, all C
+  extensions are required together or none of them will be used. This
+  prevents strange errors that arise from a mismatch of Python and C
+  implementations. See `issue 131 <https://github.com/zopefoundation/persistent/issues/131>`_.
+
+  Note that some private implementation details such as the names of
+  the pure-Python implementations have changed.
 
 - Fix ``PersistentList`` to mark itself as changed after calling
   ``clear``. See `PR 115 <https://github.com/zopefoundation/persistent/pull/115/>`_.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
     TWINE_USERNAME: zope.wheelbuilder
     TWINE_PASSWORD:
       secure: UcdTh6W78cRLVGfKRFoa5A==
+    PURE_PYTHON: 0
 
   matrix:
     - python: 27

--- a/persistent/__init__.py
+++ b/persistent/__init__.py
@@ -29,20 +29,21 @@ __all__ = [
     'TimeStamp',
 ]
 
-from persistent.interfaces import IPersistent
-
-import persistent.timestamp as TimeStamp
-
+# Take care not to shadow the module names
+from persistent import interfaces as _interfaces
+from persistent import timestamp as _timestamp
 from persistent import persistence as _persistence
 from persistent import picklecache as _picklecache
 
+IPersistent = _interfaces.IPersistent
 Persistent = _persistence.Persistent
-PersistentPy = _persistence.PersistentPy
-GHOST = _persistence.GHOST
-UPTODATE = _persistence.UPTODATE
-CHANGED = _persistence.CHANGED
-STICKY = _persistence.STICKY
+GHOST = _interfaces.GHOST
+UPTODATE = _interfaces.UPTODATE
+CHANGED = _interfaces.CHANGED
+STICKY = _interfaces.STICKY
 PickleCache = _picklecache.PickleCache
-PickleCachePy = _picklecache.PickleCachePy
+
+# BWC for TimeStamp.
+TimeStamp = _timestamp
 
 sys.modules['persistent.TimeStamp'] = sys.modules['persistent.timestamp']

--- a/persistent/__init__.py
+++ b/persistent/__init__.py
@@ -28,38 +28,21 @@ __all__ = [
     'PickleCache',
     'TimeStamp',
 ]
-from persistent._compat import PURE_PYTHON
+
 from persistent.interfaces import IPersistent
-from persistent.interfaces import IPickleCache
 
 import persistent.timestamp as TimeStamp
 
-from persistent import persistence as pyPersistence
-from persistent import picklecache as pyPickleCache
-
-try:
-    # Be careful not to shadow the modules
-    from persistent import cPersistence as _cPersistence
-    from persistent import cPickleCache as _cPickleCache
-except ImportError: # pragma: no cover
-    _cPersistence = None
-    _cPickleCache = None
-else:
-    # Make an interface declaration for Persistent
-    # Note that the Python version already does this.
-    from zope.interface import classImplements
-    classImplements(_cPersistence.Persistent, IPersistent)
-    classImplements(_cPickleCache.PickleCache, IPickleCache)
-
-
-_persistence = pyPersistence if PURE_PYTHON or _cPersistence is None else _cPersistence
-_picklecache = pyPickleCache if PURE_PYTHON or _cPickleCache is None else _cPickleCache
+from persistent import persistence as _persistence
+from persistent import picklecache as _picklecache
 
 Persistent = _persistence.Persistent
+PersistentPy = _persistence.PersistentPy
 GHOST = _persistence.GHOST
 UPTODATE = _persistence.UPTODATE
 CHANGED = _persistence.CHANGED
 STICKY = _persistence.STICKY
 PickleCache = _picklecache.PickleCache
+PickleCachePy = _picklecache.PickleCachePy
 
 sys.modules['persistent.TimeStamp'] = sys.modules['persistent.timestamp']

--- a/persistent/_compat.py
+++ b/persistent/_compat.py
@@ -14,9 +14,23 @@
 
 import sys
 import os
+import types
 
-PURE_PYTHON = os.environ.get('PURE_PYTHON')
+from zope.interface import implementedBy
+from zope.interface import classImplements
 
+__all__ = [
+    'use_c_impl',
+    'copy_reg',
+    'IterableUserDict',
+    'UserList',
+    'intern',
+    'PYPY',
+    'PYTHON3',
+    'PYTHON2',
+]
+
+# pylint:disable=import-error,self-assigning-variable
 if sys.version_info[0] > 2:
     import copyreg as copy_reg
     from collections import UserDict as IterableUserDict
@@ -25,7 +39,6 @@ if sys.version_info[0] > 2:
 
     PYTHON3 = True
     PYTHON2 = False
-
 else: # pragma: no cover
     import copy_reg
     from UserDict import IterableUserDict
@@ -35,3 +48,179 @@ else: # pragma: no cover
     PYTHON2 = True
 
     intern = intern
+
+PYPY = hasattr(sys, 'pypy_version_info')
+
+
+def _c_optimizations_required():
+    """
+    Return a true value if the C optimizations are required.
+
+    This uses the ``PURE_PYTHON`` variable as documented in `_use_c_impl`.
+    """
+    pure_env = os.environ.get('PURE_PYTHON')
+    require_c = pure_env == "0"
+    return require_c
+
+
+def _c_optimizations_available():
+    """
+    Return the C optimization modules, if available, otherwise
+    a false value.
+
+    If the optimizations are required but not available, this
+    raises the ImportError. Either all optimization modules are
+    available or none are.
+
+    This does not say whether they should be used or not.
+    """
+    catch = () if _c_optimizations_required() else (ImportError,)
+    try:
+        from persistent import cPersistence
+        from persistent import cPickleCache
+        from persistent import _timestamp
+        return {
+            'persistent.persistence': cPersistence,
+            'persistent.picklecache': cPickleCache,
+            'persistent.timestamp': _timestamp,
+        }
+    except catch: # pragma: no cover (only Jython doesn't build extensions)
+        return {}
+
+
+def _c_optimizations_ignored():
+    """
+    The opposite of `_c_optimizations_required`.
+    """
+    pure_env = os.environ.get('PURE_PYTHON')
+    # The extensions can be compiled with PyPy 7.3, but they don't work.
+    return PYPY or (pure_env is not None and pure_env != "0")
+
+
+def _should_attempt_c_optimizations():
+    """
+    Return a true value if we should attempt to use the C optimizations.
+
+    This takes into account whether we're on PyPy and the value of the
+    ``PURE_PYTHON`` environment variable, as defined in `_use_c_impl`.
+    """
+    if _c_optimizations_required():
+        return True
+    if PYPY: # pragma: no cover
+        return False
+    return not _c_optimizations_ignored()
+
+
+def use_c_impl(py_impl, name=None, globs=None):
+    """
+    Decorator. Given an object implemented in Python, with a name like
+    ``Foo``, import the corresponding C implementation from
+    ``persistent.c<NAME>`` with the name ``Foo`` and use it instead
+    (where ``NAME`` is the module name).
+
+    This can also be used for constants and other things that do not
+    have a name by passing the name as the second argument.
+
+    Example::
+
+        @use_c_impl
+        class Foo(object):
+            ...
+
+        GHOST = use_c_impl(12, 'GHOST')
+
+    If the ``PURE_PYTHON`` environment variable is set to any value
+    other than ``"0"``, or we're on PyPy, ignore the C implementation
+    and return the Python version. If the C implementation cannot be
+    imported, return the Python version. If ``PURE_PYTHON`` is set to
+    0, *require* the C implementation (let the ImportError propagate);
+    note that PyPy can import the C implementation in this case (and
+    all tests pass).
+
+    In all cases, the Python version is kept available in the module
+    globals with the name ``FooPy``.
+
+    If the Python version is a class that implements interfaces, then
+    the C version will be declared to also implement those interfaces.
+
+    If the Python version is a class, then each function defined
+    directly in that class will be replaced with a new version using
+    globals that still use the original name of the class for the
+    Python implementation. This lets the function bodies refer to the
+    class using the name the class is defined with, as it would
+    expect. (Only regular functions and static methods are handled.)
+    However, it also means that mutating the module globals later on
+    will not be visible to the methods of the class. In this example,
+    ``Foo().method()`` will always return 1::
+
+        GLOBAL_OBJECT = 1
+        @use_c_impl
+        class Foo(object):
+            def method(self):
+                super(Foo, self).method()
+                return GLOBAL_OBJECT
+        GLOBAL_OBJECT = 2
+    """
+    name = name or py_impl.__name__
+    globs = globs or sys._getframe(1).f_globals
+    mod_name = globs['__name__']
+
+    def find_impl():
+        if not _should_attempt_c_optimizations():
+            return py_impl
+
+        c_opts = _c_optimizations_available()
+        if not c_opts: # pragma: no cover (only Jython doesn't build extensions)
+            return py_impl
+
+        __traceback_info__ = c_opts
+        c_opt = c_opts[mod_name]
+        return getattr(c_opt, name)
+
+    c_impl = find_impl()
+    # Always make available by the FooPy name
+    globs[name + 'Py'] = py_impl
+
+    if c_impl is not py_impl and isinstance(py_impl, type):
+        # Rebind the globals of all the functions to still see the
+        # object under its original class name, so that references
+        # in function bodies work as expected.
+        py_attrs = vars(py_impl)
+        new_globals = None
+        for k, v in list(py_attrs.items()):
+            static = isinstance(v, staticmethod)
+            if static:
+                # Often this is __new__
+                v = v.__func__
+
+            if not isinstance(v, types.FunctionType):
+                continue
+
+            # Somewhat surprisingly, on Python 2, while
+            # ``Class.function`` results in a
+            # ``types.UnboundMethodType`` (``instancemethed``) object,
+            # ``Class.__dict__["function"]`` returns a
+            # ``types.FunctionType``, just like ``Class.function``
+            # (and the dictionary access, of course) does on Python 3.
+            # The upshot is, we don't need different version-dependent
+            # code. Hooray!
+            if new_globals is None:
+                new_globals = v.__globals__.copy()
+                new_globals[py_impl.__name__] = py_impl
+            # On Python 2, all arguments are optional, but an Python 3, all
+            # are required.
+            v = types.FunctionType(
+                v.__code__,
+                new_globals,
+                k, # name
+                v.__defaults__,
+                v.__closure__,
+            )
+            if static:
+                v = staticmethod(v)
+            setattr(py_impl, k, v)
+        # copy the interface declarations.
+        implements = list(implementedBy(py_impl))
+        if implements:
+            classImplements(c_impl, *implements)
+    return c_impl

--- a/persistent/interfaces.py
+++ b/persistent/interfaces.py
@@ -17,17 +17,17 @@
 from zope.interface import Interface
 from zope.interface import Attribute
 
-# Allowed values for _p_state
-try:
-    from persistent.cPersistence import GHOST
-    from persistent.cPersistence import UPTODATE
-    from persistent.cPersistence import CHANGED
-    from persistent.cPersistence import STICKY
-except ImportError: # pragma: no cover
-    GHOST = -1
-    UPTODATE = 0
-    CHANGED = 1
-    STICKY = 2
+from persistent._compat import use_c_impl
+
+
+# Allowed values for _p_state. Use the C constants if available (which
+# are defined in cPersistence --- there is no cInterfaces --- so we
+# need to pass the corresponding ``mod_name``), otherwise define some
+# values here.
+GHOST = use_c_impl(-1, 'GHOST', mod_name='persistent.persistence')
+UPTODATE = use_c_impl(0, 'UPTODATE', mod_name='persistent.persistence')
+CHANGED = use_c_impl(1, 'CHANGED', mod_name='persistent.persistence')
+STICKY = use_c_impl(2, 'STICKY', mod_name='persistent.persistence')
 
 
 OID_TYPE = SERIAL_TYPE = bytes

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -11,22 +11,30 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
+import functools
 import struct
 
 from zope.interface import implementer
-
-from persistent.interfaces import IPersistent
-from persistent.interfaces import GHOST
-from persistent.interfaces import UPTODATE
-from persistent.interfaces import CHANGED
-from persistent.interfaces import STICKY
-
+from persistent import interfaces
 from persistent.interfaces import SERIAL_TYPE
 from persistent.timestamp import TimeStamp
 from persistent.timestamp import _ZERO
 from persistent._compat import copy_reg
 from persistent._compat import intern
+from persistent._compat import use_c_impl
 
+# We use implementation details of PickleCachePy
+# pylint:disable=protected-access
+# we have lots of not-quite-correct continuation indentation.
+# TODO: Fix that in a whitespace-only commit.
+# pylint:disable=bad-continuation
+# There are a few places we need to work with exact types.
+# pylint:disable=unidiomatic-typecheck
+
+GHOST = use_c_impl(interfaces.GHOST, 'GHOST')
+UPTODATE = use_c_impl(interfaces.UPTODATE, 'UPTODATE')
+CHANGED = use_c_impl(interfaces.CHANGED, 'CHANGED')
+STICKY = use_c_impl(interfaces.STICKY, 'STICKY')
 
 _INITIAL_SERIAL = _ZERO
 
@@ -52,16 +60,23 @@ SPECIAL_NAMES = ('__class__',
 # check in __getattribute__
 _SPECIAL_NAMES = set(SPECIAL_NAMES)
 
+_SLOTS = ('__jar', '__oid', '__serial', '__flags', '__size', '__ring',)
+_SPECIAL_NAMES.update([intern('_Persistent' + x) for x in _SLOTS])
+
+
 # Represent 8-byte OIDs as hex integer, just like
 # ZODB does.
 _OID_STRUCT = struct.Struct('>Q')
 _OID_UNPACK = _OID_STRUCT.unpack
 
-@implementer(IPersistent)
+
+
+@use_c_impl
+@implementer(interfaces.IPersistent)
 class Persistent(object):
     """ Pure Python implmentation of Persistent base class
     """
-    __slots__ = ('__jar', '__oid', '__serial', '__flags', '__size', '__ring',)
+    __slots__ = _SLOTS
 
     def __new__(cls, *args, **kw):
         inst = super(Persistent, cls).__new__(cls)
@@ -183,9 +198,7 @@ class Persistent(object):
         self._p_activate()
         self._p_accessed()
         serial = _OGA(self, '_Persistent__serial')
-        if serial is not None:
-            ts = TimeStamp(serial)
-            return ts.timeTime()
+        return TimeStamp(serial).timeTime() if serial is not None else None
 
     _p_mtime = property(_get_mtime)
 
@@ -314,7 +327,7 @@ class Persistent(object):
                    if not x.startswith('_p_') and
                       not (x.startswith('_v_') and _v_exclude) and
                       not x.startswith('_Persistent__') and
-                      x not in Persistent.__slots__]
+                      x not in _SLOTS]
 
     def __getstate__(self):
         """ See IPersistent.
@@ -322,6 +335,9 @@ class Persistent(object):
         idict = getattr(self, '__dict__', None)
         slotnames = self._slotnames()
         if idict is not None:
+            # TODO: Convert to a dictionary comprehension, avoid the intermediate
+            # list.
+            # pylint:disable=consider-using-dict-comprehension
             d = dict([x for x in idict.items()
                          if not x[0].startswith('_p_') and
                             not x[0].startswith('_v_')])
@@ -339,7 +355,7 @@ class Persistent(object):
     def __setstate__(self, state):
         """ See IPersistent.
         """
-        if isinstance(state,tuple):
+        if isinstance(state, tuple):
             inst_dict, slots = state
         else:
             inst_dict, slots = state, ()
@@ -548,7 +564,7 @@ class Persistent(object):
         # The AttributeError arises in ZODB test cases
         try:
             jar._cache.mru(oid)
-        except (AttributeError,KeyError):
+        except (AttributeError, KeyError):
             pass
 
 
@@ -561,8 +577,10 @@ class Persistent(object):
         cache = getattr(jar, '_cache', None)
         if cache is not None:
             return cache.get(oid) is self
+        return None
 
     def __repr__(self):
+        # pylint:disable=broad-except
         p_repr_str = ''
         p_repr = getattr(type(self), '_p_repr', None)
         if p_repr is not None:
@@ -595,7 +613,8 @@ class Persistent(object):
         return '<%s.%s object at 0x%x%s%s%s>' % (
             # Match the C name for this exact class
             type(self).__module__ if type(self) is not Persistent else 'persistent',
-            type(self).__name__, id(self),
+            type(self).__name__ if type(self) is not Persistent else 'Persistent',
+            id(self),
             oid_str, jar_str, p_repr_str
         )
 
@@ -604,5 +623,3 @@ def _estimated_size_in_24_bits(value):
     if value > 1073741696:
         return 16777215
     return (value//64) + 1
-
-_SPECIAL_NAMES.update([intern('_Persistent' + x) for x in Persistent.__slots__])

--- a/persistent/picklecache.py
+++ b/persistent/picklecache.py
@@ -28,6 +28,11 @@ from persistent.persistence import PersistentPy
 from persistent.persistence import _estimated_size_in_24_bits
 from persistent.ring import Ring
 
+__all__ = [
+    'PickleCache',
+    'PickleCachePy',
+]
+
 # We're tightly coupled to the PersistentPy implementation and access
 # its internals.
 # pylint:disable=protected-access
@@ -36,7 +41,7 @@ from persistent.ring import Ring
 # On Jython, we need to explicitly ask it to monitor
 # objects if we want a more deterministic GC
 if hasattr(gc, 'monitorObject'): # pragma: no cover
-    _gc_monitor = gc.monitorObject
+    _gc_monitor = gc.monitorObject # pylint:disable=no-member
 else:
     def _gc_monitor(o):
         pass
@@ -56,8 +61,6 @@ def _sweeping_ring(f):
             self._is_sweeping_ring = False
     return locked
 
-# This name will be replaced by the use_c_impl decorator.
-PickleCachePy = None
 
 @use_c_impl
 # We actually implement IExtendedPickleCache, but
@@ -407,4 +410,7 @@ class PickleCache(object):
                 pass
 
 
+# This name is bound by the ``@use_c_impl`` decorator to the class defined above.
+# We make sure and list it statically, though, to help out linters.
+PickleCachePy = PickleCachePy # pylint:disable=undefined-variable,self-assigning-variable
 classImplements(PickleCachePy, IExtendedPickleCache)

--- a/persistent/tests/test__compat.py
+++ b/persistent/tests/test__compat.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Tests for ``persistent._compat``
+
+"""
+
+import unittest
+import os
+
+from persistent import _compat as compat
+
+class TestCOptimizationsFuncs(unittest.TestCase):
+    # pylint:disable=protected-access
+    def setUp(self):
+        self.env_val = os.environ.get('PURE_PYTHON', self)
+        self.orig_pypy = compat.PYPY
+        compat.PYPY = False
+
+    def tearDown(self):
+        compat.PYPY = self.orig_pypy
+        if self.env_val is not self:
+            # Reset to what it was to begin with.
+            os.environ['PURE_PYTHON'] = self.env_val
+        else: # pragma: no cover
+            # It wasn't present before, make sure it's not present now.
+            os.environ.pop('PURE_PYTHON', None)
+
+        self.env_val = None
+
+    def _set_env(self, val):
+        if val is not None:
+            os.environ['PURE_PYTHON'] = val
+        else:
+            os.environ.pop('PURE_PYTHON', None)
+
+    def test_ignored_no_env_val(self):
+        self._set_env(None)
+        self.assertFalse(compat._c_optimizations_ignored())
+
+    def test_ignored_zero(self):
+        self._set_env('0')
+        self.assertFalse(compat._c_optimizations_ignored())
+
+    def test_ignored_empty(self):
+        self._set_env('')
+        self.assertFalse(compat._c_optimizations_ignored())
+
+    def test_ignored_other_values(self):
+        for val in "1", "yes", "hi":
+            self._set_env(val)
+            self.assertTrue(compat._c_optimizations_ignored())
+
+    def test_ignored_pypy(self):
+        # No matter what the environment variable is, PyPy always ignores
+        compat.PYPY = True
+        for val in None, "", "0", "1", "yes":
+            __traceback_info__ = val
+            self._set_env(val)
+            self.assertTrue(compat._c_optimizations_ignored())
+
+    def test_required(self):
+        for val, expected in (
+                ('', False),
+                ('0', True),
+                ('1', False),
+                ('Yes', False)
+        ):
+            self._set_env(val)
+            self.assertEqual(expected, compat._c_optimizations_required())
+
+    def test_should_attempt(self):
+        for val, expected in (
+                (None, True),
+                ('', True),
+                ('0', True),
+                ('1', False),
+                ('Yes', False)
+        ):
+            self._set_env(val)
+            self.assertEqual(expected, compat._should_attempt_c_optimizations())
+
+    def test_should_attempt_pypy(self):
+        compat.PYPY = True
+        for val, expected in (
+                (None, False),
+                ('', False),
+                ('0', True),
+                ('1', False),
+                ('Yes', False)
+        ):
+            __traceback_info__ = val
+            self._set_env(val)
+            self.assertEqual(expected, compat._should_attempt_c_optimizations())

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -1936,9 +1936,9 @@ class _Persistent_Base(object):
 class PyPersistentTests(unittest.TestCase, _Persistent_Base):
 
     def _getTargetClass(self):
-        from persistent.persistence import PersistentPy as Persistent
-        assert Persistent.__module__ == 'persistent.persistence', Persistent.__module__
-        return Persistent
+        from persistent.persistence import PersistentPy
+        assert PersistentPy.__module__ == 'persistent.persistence', PersistentPy.__module__
+        return PersistentPy
 
     def _makeCache(self, jar):
 

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -17,8 +17,9 @@ import re
 import sys
 import unittest
 
-import persistent
+
 from persistent._compat import copy_reg
+from persistent.tests.utils import skipIfNoCExtension
 
 
 _is_pypy3 = platform.python_implementation() == 'PyPy' and sys.version_info[0] > 2
@@ -28,11 +29,6 @@ _is_pypy3 = platform.python_implementation() == 'PyPy' and sys.version_info[0] >
 # pylint:disable=blacklisted-name,useless-object-inheritance
 # Hundreds of unused jar and OID vars make this useless
 # pylint:disable=unused-variable
-
-def skipIfNoCExtension(o):
-    return unittest.skipIf(
-        persistent._cPersistence is None,
-        "The C extension is not available")(o)
 
 
 class _Persistent_Base(object):
@@ -1079,10 +1075,21 @@ class _Persistent_Base(object):
         self.assertEqual(second, (Derived, 'a', 'b'))
         self.assertEqual(third, {'foo': 'bar'})
 
+    def _get_cucumber(self, name):
+        # Checks that it's actually a subclass of what we're testing;
+        # if it isn't, the test is skipped. The cucumbers module can
+        # only subclass either the C or Python implementation, not
+        # both
+        from persistent.tests import cucumbers
+        cls = getattr(cucumbers, name)
+        if not issubclass(cls, self._getTargetClass()):
+            self.skipTest("Cucumber is not correct implementation")
+        return cls
+
     def test_pickle_roundtrip_simple(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import Simple
+        Simple = self._get_cucumber('Simple')
         inst = Simple('testing')
         copy = pickle.loads(pickle.dumps(inst))
         self.assertEqual(copy, inst)
@@ -1093,7 +1100,7 @@ class _Persistent_Base(object):
     def test_pickle_roundtrip_w_getnewargs_and_getstate(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import Custom
+        Custom = self._get_cucumber('Custom')
         inst = Custom('x', 'y')
         copy = pickle.loads(pickle.dumps(inst))
         self.assertEqual(copy, inst)
@@ -1104,7 +1111,7 @@ class _Persistent_Base(object):
     def test_pickle_roundtrip_w_slots_missing_slot(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import SubSlotted
+        SubSlotted = self._get_cucumber('SubSlotted')
         inst = SubSlotted('x', 'y', 'z')
         copy = pickle.loads(pickle.dumps(inst))
         self.assertEqual(copy, inst)
@@ -1115,7 +1122,7 @@ class _Persistent_Base(object):
     def test_pickle_roundtrip_w_slots_filled_slot(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import SubSlotted
+        SubSlotted = self._get_cucumber('SubSlotted')
         inst = SubSlotted('x', 'y', 'z')
         inst.s4 = 'a'
         copy = pickle.loads(pickle.dumps(inst))
@@ -1127,7 +1134,7 @@ class _Persistent_Base(object):
     def test_pickle_roundtrip_w_slots_and_empty_dict(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import SubSubSlotted
+        SubSubSlotted = self._get_cucumber('SubSubSlotted')
         inst = SubSubSlotted('x', 'y', 'z')
         copy = pickle.loads(pickle.dumps(inst))
         self.assertEqual(copy, inst)
@@ -1138,7 +1145,7 @@ class _Persistent_Base(object):
     def test_pickle_roundtrip_w_slots_and_filled_dict(self):
         import pickle
         # XXX s.b. 'examples'
-        from persistent.tests.cucumbers import SubSubSlotted
+        SubSubSlotted = self._get_cucumber('SubSubSlotted')
         inst = SubSubSlotted('x', 'y', 'z', foo='bar', baz='bam')
         inst.s4 = 'a'
         copy = pickle.loads(pickle.dumps(inst))
@@ -1362,22 +1369,39 @@ class _Persistent_Base(object):
 
     def test__p_invalidate_from_changed_w_slots(self):
         class Derived(self._getTargetClass()):
-            __slots__ = ('myattr1', 'myattr2', 'unset')
+            __slots__ = {
+                'myattr1': 'value1',
+                'myattr2': 'value2',
+                'unset': None
+            }
+
             def __init__(self):
                 self.myattr1 = 'value1'
                 self.myattr2 = 'value2'
+
         inst, jar, OID = self._makeOneWithJar(Derived)
         inst._p_activate()
         inst._p_changed = True
         jar._loaded = []
         jar._registered = []
-        self.assertEqual(Derived.myattr1.__get__(inst), 'value1')
-        self.assertEqual(Derived.myattr2.__get__(inst), 'value2')
+        for slot, expected_value in Derived.__slots__.items():
+            slot_descriptor = getattr(Derived, slot)
+            if expected_value:
+                self.assertEqual(slot_descriptor.__get__(inst), expected_value)
+            else:
+                with self.assertRaises(AttributeError):
+                    slot_descriptor.__get__(inst)
+
         inst._p_invalidate()
         self.assertEqual(inst._p_status, 'ghost')
         self.assertEqual(list(jar._loaded), [])
-        self.assertRaises(AttributeError, lambda: Derived.myattr1.__get__(inst))
-        self.assertRaises(AttributeError, lambda: Derived.myattr2.__get__(inst))
+
+        for slot in Derived.__slots__:
+            __traceback_info__ = slot, inst
+            slot_descriptor = getattr(Derived, slot)
+            with self.assertRaises(AttributeError):
+                slot_descriptor.__get__(inst)
+
         self.assertEqual(list(jar._loaded), [])
         self.assertEqual(list(jar._registered), [])
 
@@ -1912,7 +1936,8 @@ class _Persistent_Base(object):
 class PyPersistentTests(unittest.TestCase, _Persistent_Base):
 
     def _getTargetClass(self):
-        from persistent.persistence import Persistent
+        from persistent.persistence import PersistentPy as Persistent
+        assert Persistent.__module__ == 'persistent.persistence', Persistent.__module__
         return Persistent
 
     def _makeCache(self, jar):
@@ -1938,7 +1963,7 @@ class PyPersistentTests(unittest.TestCase, _Persistent_Base):
         return _Cache(jar)
 
     def _makeRealCache(self, jar):
-        from persistent.picklecache import PickleCache
+        from persistent.picklecache import PickleCachePy as PickleCache
         return PickleCache(jar, 10)
 
     def _checkMRU(self, jar, value):
@@ -2024,8 +2049,8 @@ class PyPersistentTests(unittest.TestCase, _Persistent_Base):
 class CPersistentTests(unittest.TestCase, _Persistent_Base):
 
     def _getTargetClass(self):
-        from persistent.cPersistence import Persistent
-        return Persistent
+        from persistent._compat import _c_optimizations_available as get_c
+        return get_c()['persistent.persistence'].Persistent
 
     def _checkMRU(self, jar, value):
         pass # Figure this out later
@@ -2034,7 +2059,8 @@ class CPersistentTests(unittest.TestCase, _Persistent_Base):
         pass # Figure this out later
 
     def _makeCache(self, jar):
-        from persistent.cPickleCache import PickleCache
+        from persistent._compat import _c_optimizations_available as get_c
+        PickleCache = get_c()['persistent.picklecache'].PickleCache
         return PickleCache(jar)
 
 
@@ -2042,7 +2068,8 @@ class CPersistentTests(unittest.TestCase, _Persistent_Base):
 class Test_simple_new(unittest.TestCase):
 
     def _callFUT(self, x):
-        from persistent.cPersistence import simple_new
+        from persistent._compat import _c_optimizations_available as get_c
+        simple_new = get_c()['persistent.persistence'].simple_new
         return simple_new(x)
 
     def test_w_non_type(self):

--- a/persistent/tests/utils.py
+++ b/persistent/tests/utils.py
@@ -92,3 +92,27 @@ def copy_test(self, obj):
     self.assertEqual(obj.data, obj_copy.data)
 
     return obj_copy
+
+
+def skipIfNoCExtension(o):
+    import unittest
+    from persistent._compat import _should_attempt_c_optimizations
+    from persistent._compat import _c_optimizations_available
+    from persistent._compat import _c_optimizations_ignored
+
+    if _should_attempt_c_optimizations() and not _c_optimizations_available(): # pragma: no cover
+        return unittest.expectedFailure(o)
+    return unittest.skipIf(
+        _c_optimizations_ignored() or not _c_optimizations_available(),
+        "The C extension is not available"
+    )(o)
+
+
+def skipIfPurePython(o):
+    import unittest
+    from persistent._compat import _should_attempt_c_optimizations
+
+    return unittest.skipUnless(
+        _should_attempt_c_optimizations(),
+        "Cannot mix and match implementations"
+    )(o)

--- a/persistent/timestamp.py
+++ b/persistent/timestamp.py
@@ -18,7 +18,7 @@ import math
 import struct
 import sys
 
-from persistent._compat import PURE_PYTHON
+from persistent._compat import use_c_impl
 
 _RAWTYPE = bytes
 _MAXINT = sys.maxsize
@@ -79,8 +79,10 @@ def _parseRaw(octets):
     second = b * _TS_SECOND_BYTES_BIAS
     return (year, month, day, hour, minute, second)
 
+TimeStampPy = None
 
-class pyTimeStamp(object):
+@use_c_impl
+class TimeStamp(object):
     __slots__ = ('_raw', '_elements')
 
     def __init__(self, *args):
@@ -210,11 +212,3 @@ class pyTimeStamp(object):
             return self.raw() >= other.raw()
         except AttributeError:
             return NotImplemented
-
-
-try:
-    from persistent._timestamp import TimeStamp as CTimeStamp
-except ImportError: # pragma: no cover
-    CTimeStamp = None
-
-TimeStamp = pyTimeStamp if PURE_PYTHON or CTimeStamp is None else CTimeStamp

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,12 @@
 ##############################################################################
 
 import os
-import platform
 
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
 
-version = '4.5.2.dev0'
+version = '4.6.0.dev0'
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -31,64 +30,52 @@ def _read_file(filename):
 
 README = (_read_file('README.rst') + '\n\n' + _read_file('CHANGES.rst'))
 
-is_pypy = platform.python_implementation() == 'PyPy'
 
-# On PyPy the C optimizations are
-# anti-optimizations (the C extension compatibility layer is known-slow,
-# and defeats JIT opportunities); PyPy 6.0 can compile them, but the
-# tests fail and they actually crash the VM.
-if is_pypy:
-    # Note that all the lists we pass to setuptools must be distinct
-    # objects, or bad things happen.
-    # See https://github.com/zopefoundation/persistent/issues/88
-    ext_modules = []
-    headers = []
-else:
-    define_macros = (
-        # We currently use macros like PyBytes_AS_STRING
-        # and internal functions like _PyObject_GetDictPtr
-        # that make it impossible to use the stable (limited) API.
-        # ('Py_LIMITED_API', '0x03050000'),
-    )
-    ext_modules = [
-        Extension(
-            name='persistent.cPersistence',
-            sources=[
-                'persistent/cPersistence.c',
-                'persistent/ring.c',
-            ],
-            depends=[
-                'persistent/cPersistence.h',
-                'persistent/ring.h',
-                'persistent/ring.c',
-            ],
-            define_macros=list(define_macros),
-        ),
-        Extension(
-            name='persistent.cPickleCache',
-            sources=[
-                'persistent/cPickleCache.c',
-                'persistent/ring.c',
-            ],
-            depends=[
-                'persistent/cPersistence.h',
-                'persistent/ring.h',
-                'persistent/ring.c',
-            ],
-            define_macros=list(define_macros),
-        ),
-        Extension(
-            name='persistent._timestamp',
-            sources=[
-                'persistent/_timestamp.c',
-            ],
-            define_macros=list(define_macros),
-        ),
-    ]
-    headers = [
-        'persistent/cPersistence.h',
-        'persistent/ring.h',
-    ]
+define_macros = (
+    # We currently use macros like PyBytes_AS_STRING
+    # and internal functions like _PyObject_GetDictPtr
+    # that make it impossible to use the stable (limited) API.
+    # ('Py_LIMITED_API', '0x03050000'),
+)
+ext_modules = [
+    Extension(
+        name='persistent.cPersistence',
+        sources=[
+            'persistent/cPersistence.c',
+            'persistent/ring.c',
+        ],
+        depends=[
+            'persistent/cPersistence.h',
+            'persistent/ring.h',
+            'persistent/ring.c',
+        ],
+        define_macros=list(define_macros),
+    ),
+    Extension(
+        name='persistent.cPickleCache',
+        sources=[
+            'persistent/cPickleCache.c',
+            'persistent/ring.c',
+        ],
+        depends=[
+            'persistent/cPersistence.h',
+            'persistent/ring.h',
+            'persistent/ring.c',
+        ],
+        define_macros=list(define_macros),
+    ),
+    Extension(
+        name='persistent._timestamp',
+        sources=[
+            'persistent/_timestamp.c',
+        ],
+        define_macros=list(define_macros),
+    ),
+]
+headers = [
+    'persistent/cPersistence.h',
+    'persistent/ring.h',
+]
 
 setup(name='persistent',
       version=version,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,py37-pure,py38,py27-pure,py27-pure-cffi,pypy, pypy3,coverage,docs
+    py27,py35,py36,py37,py37-pure,py38,py27-pure,pypy,pypy3,coverage,docs
 
 [testenv]
 deps =
@@ -9,12 +9,6 @@ commands =
     zope-testrunner --test-path=. []
 
 [testenv:py27-pure]
-basepython =
-    python2.7
-setenv =
-    PURE_PYTHON = 1
-
-[testenv:py27-pure-cffi]
 basepython =
     python2.7
 setenv =
@@ -32,6 +26,8 @@ basepython =
     python3.6
 commands =
     coverage run -m zope.testrunner --test-path=.
+    python -c 'import os, subprocess; subprocess.check_call("coverage run -a -m zope.testrunner --test-path=.", env=dict(os.environ, PURE_PYTHON="1"), shell=True)'
+    python -c 'import os, subprocess; subprocess.check_call("coverage run -a -m zope.testrunner --test-path=.", env=dict(os.environ, PURE_PYTHON="0"), shell=True)'
     coverage report --fail-under=100
 deps =
     {[testenv]deps}


### PR DESCRIPTION
With PURE_PYTHON=0, like in zope.interface.

Also always require all three extensions. This solves mysterious issues you can get if you wind up mixing and matching (#124).

Fixes #131

Add travis and tox tests for this.