### PR TITLE
Use ffi.gc() on the ring nodes to avoid needing a weakref to PersistentPy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,12 @@
 - Add support for Python 3.9a3+.
   See `issue 124 <https://github.com/zopefoundation/persistent/issues/124>`_.
 
+- Fix the Python implementation of the PickleCache to be able to store
+  objects that cannot be weakly referenced. See `issue 133
+  <https://github.com/zopefoundation/persistent/issues/133>`_.
+
+  Note that ``ctypes`` is required to use the Python implementation
+  (except on PyPy).
 
 4.5.1 (2019-11-06)
 ------------------

--- a/persistent/_ring_build.py
+++ b/persistent/_ring_build.py
@@ -21,10 +21,42 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 
 ffi = FFI()
 with open(os.path.join(this_dir, 'ring.h')) as f:
-    ffi.cdef(f.read())
+    cdefs = f.read()
+
+# Define a structure with the same layout as CPersistentRing,
+# and an extra member. We'll cast between them to reuse the
+# existing functions.
+struct_def = """
+typedef struct CPersistentRingCFFI_struct
+{
+    struct CPersistentRing_struct *r_prev;
+    struct CPersistentRing_struct *r_next;
+    intptr_t pobj_id; /* The id(PersistentPy object) */
+} CPersistentRingCFFI;
+"""
+
+cdefs += struct_def + """
+void cffi_ring_add(CPersistentRing* ring, void* elt);
+void cffi_ring_del(void* elt);
+void cffi_ring_move_to_head(CPersistentRing* ring, void* elt);
+"""
+
+ffi.cdef(cdefs)
+
+source = """
+#include "ring.c"
+""" + struct_def + """
+
+/* Like the other functions, but taking the CFFI version of the struct. This
+ * saves casting at runtime in Python.
+ */
+#define cffi_ring_add(ring, elt) ring_add((CPersistentRing*)ring, (CPersistentRing*)elt)
+#define cffi_ring_del(elt) ring_del((CPersistentRing*)elt)
+#define cffi_ring_move_to_head(ring, elt) ring_move_to_head((CPersistentRing*)ring, (CPersistentRing*)elt)
+"""
 
 ffi.set_source('persistent._ring',
-               '#include "ring.c"',
+               source,
                include_dirs=[this_dir])
 
 if __name__ == '__main__':

--- a/persistent/cPersistence.h
+++ b/persistent/cPersistence.h
@@ -28,13 +28,13 @@
 
 struct ccobject_head_struct;
 
-typedef struct ccobject_head_struct PerCache;    
+typedef struct ccobject_head_struct PerCache;
 
 /* How big is a persistent object?
 
    12  PyGC_Head is two pointers and an int
     8  PyObject_HEAD is an int and a pointer
- 
+
    12  jar, oid, cache pointers
     8  ring struct
     8  serialno
@@ -67,7 +67,7 @@ typedef struct ccobject_head_struct PerCache;
    unsigned long field after a signed char state field and a
    3-character reserved field.  This didn't work because there
    are packages in the wild that have their own copies of cPersistence.h
-   that didn't see the update.  
+   that didn't see the update.
 
    To get around this, we used the reserved space by making
    estimated_size a 24-bit bit field in the space occupied by the old
@@ -132,14 +132,14 @@ static cPersistenceCAPIstruct *cPersistenceCAPI;
 
 #define PER_PREVENT_DEACTIVATION(O)  ((O)->state==cPersistent_UPTODATE_STATE && ((O)->state=cPersistent_STICKY_STATE))
 
-/* 
+/*
    Make a persistent object usable from C by:
 
    - Making sure it is not a ghost
 
    - Making it sticky.
 
-   IMPORTANT: If you call this and don't call PER_ALLOW_DEACTIVATION, 
+   IMPORTANT: If you call this and don't call PER_ALLOW_DEACTIVATION,
               your object will not be ghostified.
 
    PER_USE returns a 1 on success and 0 failure, where failure means

--- a/persistent/persistence.py
+++ b/persistent/persistence.py
@@ -59,6 +59,7 @@ SPECIAL_NAMES = ('__class__',
 # check in __getattribute__
 _SPECIAL_NAMES = set(SPECIAL_NAMES)
 
+# __ring is for use by PickleCachePy and is opaque to us.
 _SLOTS = ('__jar', '__oid', '__serial', '__flags', '__size', '__ring',)
 _SPECIAL_NAMES.update([intern('_Persistent' + x) for x in _SLOTS])
 

--- a/persistent/ring.c
+++ b/persistent/ring.c
@@ -43,6 +43,7 @@ ring_add(CPersistentRing *ring, CPersistentRing *elt)
 void
 ring_del(CPersistentRing *elt)
 {
+    assert(elt->r_next);
     elt->r_next->r_prev = elt->r_prev;
     elt->r_prev->r_next = elt->r_next;
     elt->r_next = NULL;
@@ -52,6 +53,7 @@ ring_del(CPersistentRing *elt)
 void
 ring_move_to_head(CPersistentRing *ring, CPersistentRing *elt)
 {
+    assert(elt->r_next);
     elt->r_prev->r_next = elt->r_next;
     elt->r_next->r_prev = elt->r_prev;
     elt->r_next = ring;

--- a/persistent/ring.h
+++ b/persistent/ring.h
@@ -38,6 +38,7 @@ typedef struct CPersistentRing_struct
     struct CPersistentRing_struct *r_next;
 } CPersistentRing;
 
+
 /* The list operations here take constant time independent of the
  * number of objects in the list:
  */

--- a/persistent/tests/test_persistence.py
+++ b/persistent/tests/test_persistence.py
@@ -12,17 +12,15 @@
 #
 ##############################################################################
 
-import platform
 import re
-import sys
 import unittest
 
-
 from persistent._compat import copy_reg
+from persistent._compat import PYPY
+from persistent._compat import PYTHON3 as PY3
 from persistent.tests.utils import skipIfNoCExtension
 
-
-_is_pypy3 = platform.python_implementation() == 'PyPy' and sys.version_info[0] > 2
+_is_pypy3 = PYPY and PY3
 
 # pylint:disable=R0904,W0212,E1101
 # pylint:disable=attribute-defined-outside-init,too-many-lines
@@ -119,6 +117,14 @@ class _Persistent_Base(object):
         from zope.interface.verify import verifyObject
         from persistent.interfaces import IPersistent
         verifyObject(IPersistent, self._makeOne())
+
+    def test_instance_cannot_be_weakly_referenced(self):
+        if PYPY: # pragma: no cover
+            self.skipTest('On PyPy, everything can be weakly referenced')
+        import weakref
+        inst = self._makeOne()
+        with self.assertRaises(TypeError):
+            weakref.ref(inst)
 
     def test_ctor(self):
         from persistent.persistence import _INITIAL_SERIAL

--- a/persistent/tests/utils.py
+++ b/persistent/tests/utils.py
@@ -106,13 +106,3 @@ def skipIfNoCExtension(o):
         _c_optimizations_ignored() or not _c_optimizations_available(),
         "The C extension is not available"
     )(o)
-
-
-def skipIfPurePython(o):
-    import unittest
-    from persistent._compat import _should_attempt_c_optimizations
-
-    return unittest.skipUnless(
-        _should_attempt_c_optimizations(),
-        "Cannot mix and match implementations"
-    )(o)


### PR DESCRIPTION
Except on PyPy, where we can already weakref them automatically. On CPython, track them using their `id` (can't use an `ffi.new_handle` "pointer" because it strongly references the object it's a handle for).

Fixes #133.