### PR TITLE
Remove faulty assertion in PersistentMapping.clear().

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@
 4.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an ``AssertionError`` clearing a non-empty ``PersistentMapping``
+  that has no connection. See `issue 139
+  <https://github.com/zopefoundation/persistent/issues/139>`_.
 
 
 4.6.1 (2020-03-06)

--- a/persistent/mapping.py
+++ b/persistent/mapping.py
@@ -101,7 +101,6 @@ class PersistentMapping(IterableUserDict, persistent.Persistent):
         self.__super_clear()
         if needs_changed:
             self._p_changed = 1
-            assert self._p_changed
 
     def update(self, *args, **kwargs):
         """

--- a/persistent/tests/test_mapping.py
+++ b/persistent/tests/test_mapping.py
@@ -273,6 +273,15 @@ class PersistentMappingTests(unittest.TestCase):
         pm.clear()
         self.assertFalse(pm._p_changed)
 
+    def test_clear_no_jar(self):
+        # https://github.com/zopefoundation/persistent/issues/139
+        self._makeOne = self._getTargetClass()
+        self.test_clear_empty()
+
+        pm = self._makeOne(a=42)
+        pm.clear()
+        self.assertFalse(pm._p_changed)
+
     def test_clear_empty_legacy_container(self):
         pm = self._makeOne()
         pm.__dict__['_container'] = pm.__dict__.pop('data')


### PR DESCRIPTION
If there's no jar, we can't be _p_changed.

Fixes #139.