### PR TITLE
Use unsigned integers to represent addresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@
 4.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a crash in the test suite under a 32-bit CPython on certain
+  platforms. See `issue 137
+  <https://github.com/zopefoundation/persistent/issues/137>`_. Fix by
+  `Jerry James <https://github.com/jamesjer>`_.
 
 
 4.6.2 (2020-03-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 ------------------
 
 - Fix a crash in the test suite under a 32-bit CPython on certain
-  platforms. See `issue 137
+  32-bit platforms. See `issue 137
   <https://github.com/zopefoundation/persistent/issues/137>`_. Fix by
   `Jerry James <https://github.com/jamesjer>`_.
 

--- a/persistent/_ring_build.py
+++ b/persistent/_ring_build.py
@@ -31,7 +31,7 @@ typedef struct CPersistentRingCFFI_struct
 {
     struct CPersistentRing_struct *r_prev;
     struct CPersistentRing_struct *r_next;
-    intptr_t pobj_id; /* The id(PersistentPy object) */
+    uintptr_t pobj_id; /* The id(PersistentPy object) */
 } CPersistentRingCFFI;
 """
 

--- a/persistent/ring.py
+++ b/persistent/ring.py
@@ -124,7 +124,7 @@ class _CFFIRing(object):
 
             if self.cleanup_func:
                 node = ffi.new('CPersistentRingCFFI*')
-                node.pobj_id = ffi.cast('intptr_t', id(persistent_object))
+                node.pobj_id = ffi.cast('uintptr_t', id(persistent_object))
                 gc_ptr = ffi.gc(node, self.cleanup_func)
             else:
                 node = ffi.new("CPersistentRing*")


### PR DESCRIPTION
Add change note.

Fixes #137

Supersedes and fixes #141 for committer agreement purposes.