### PR TITLE
Add support for static properties

### DIFF
--- a/persistent/__init__.py
+++ b/persistent/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     'STICKY',
     'PickleCache',
     'TimeStamp',
+    'static',
 ]
 
 # Take care not to shadow the module names
@@ -42,6 +43,7 @@ UPTODATE = _interfaces.UPTODATE
 CHANGED = _interfaces.CHANGED
 STICKY = _interfaces.STICKY
 PickleCache = _picklecache.PickleCache
+static = _persistence.static
 
 # BWC for TimeStamp.
 TimeStamp = _timestamp

--- a/persistent/cPersistence.h
+++ b/persistent/cPersistence.h
@@ -92,6 +92,11 @@ typedef struct {
     cPersistent_HEAD
 } cPersistentObject;
 
+typedef struct {
+    PyObject_HEAD \
+    PyObject *value;
+} cStaticObject;
+
 typedef void (*percachedelfunc)(PerCache *, PyObject *);
 
 typedef struct {


### PR DESCRIPTION
They are only assignable on the class rather than instances of it.
They can be retrieved without deghostifying classes.
They do not trigger any hooks

This is the first step towards supporting asyncio