### PR TITLE
Ask zest.releaser not to upload binary wheels.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
 [aliases]
 dev = develop easy_install persistent[testing]
 docs = develop easy_install persistent[docs]
+
+[zest.releaser]
+create-wheel = no
+
+[bdist_wheel]
+universal = 0
+
+[metadata]
+long_description_content_type = text/x-rst


### PR DESCRIPTION
We use the CI to build and upload binary wheels.

Binary wheels built on individuals' machines may use CFLAGS, etc, that are not compatible with all machines, but this is not expressed in the wheel tags. Thus, incompatible machines may download and install such wheels, leading to bad behaviour or even Illegal Instruction crashes.

Fixes #154.

Also set the long_description_content_type to avoid getting warnings from 'twine check'.