### PR TITLE
Fix the CFFI cache implementation to not print AttributeErrors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
   when setting its ``__class__`` and ``__dict__``. This matches the
   behaviour of the C implementation. See `issue 155
   <https://github.com/zopefoundation/persistent/issues/155>`_.
+- Fix the CFFI cache implementation (used on CPython when
+  ``PURE_PYTHON=1``) to not print unraisable ``AttributeErrors`` from
+  ``_WeakValueDictionary`` during garbage collection. See `issue 150
+  <https://github.com/zopefoundation/persistent/issues/150>`_.
 
 4.6.4 (2020-03-26)
 ==================

--- a/persistent/picklecache.py
+++ b/persistent/picklecache.py
@@ -102,7 +102,13 @@ class _WeakValueDictionary(object):
             return self._cast(addr, self._py_object).value
 
         def cleanup_hook(self, cdata):
-            oid = self._addr_to_oid.pop(cdata.pobj_id, None)
+            # This is called during GC, possibly at interpreter shutdown
+            # when the __dict__ of this object may have already been cleared.
+            try:
+                addr_to_oid = self._addr_to_oid
+            except AttributeError:
+                return
+            oid = addr_to_oid.pop(cdata.pobj_id, None)
             self._data.pop(oid, None)
 
     def __contains__(self, oid):

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -1136,7 +1136,8 @@ class PythonPickleCacheTests(PickleCacheTestMixin, unittest.TestCase):
         o = cache[oid] = self._makePersist(oid=oid)
         # Clear the dict, or at least part of it.
         # This is coupled to ``cleanup_hook``
-        del cache.data._addr_to_oid
+        if cache.data.cleanup_hook:
+            del cache.data._addr_to_oid
         del cache[oid]
 
         self.assertEqual(unraised, [])

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -1125,10 +1125,8 @@ class PythonPickleCacheTests(PickleCacheTestMixin, unittest.TestCase):
             old_hook = sys.unraisablehook
         except AttributeError:
             pass
-        else:
-            def new_hook(unraisable):
-                unraised.append(1)
-            sys.unraisablehook = new_hook
+        else: # pragma: no cover
+            sys.unraisablehook = unraised.append
             self.addCleanup(setattr, sys, 'unraisablehook', old_hook)
 
         cache = self._makeOne()

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -1102,6 +1102,45 @@ class PythonPickleCacheTests(PickleCacheTestMixin, unittest.TestCase):
         self.assertEqual(cache.cache_non_ghost_count, 0)
         self.assertEqual(len(cache), 0)
 
+    def test_interpreter_finalization_ffi_cleanup(self):
+        # When the interpreter is busy garbage collecting old objects
+        # and clearing their __dict__ in random orders, the CFFI cleanup
+        # ``ffi.gc()`` cleanup hooks we use on CPython don't
+        # raise errors.
+        #
+        # Prior to Python 3.8, when ``sys.unraisablehook`` was added,
+        # the only way to know if this test fails is to look for AttributeError
+        # on stderr.
+        #
+        # But wait, it gets worse. Prior to https://foss.heptapod.net/pypy/cffi/-/issues/492
+        # (CFFI > 1.14.5, unreleased at this writing), CFFI ignores
+        # ``sys.unraisablehook``, so even on 3.8 the only way to know
+        # a failure is to watch stderr.
+        #
+        # See https://github.com/zopefoundation/persistent/issues/150
+
+        import sys
+        unraised = []
+        try:
+            old_hook = sys.unraisablehook
+        except AttributeError:
+            pass
+        else:
+            def new_hook(unraisable):
+                unraised.append(1)
+            sys.unraisablehook = new_hook
+            self.addCleanup(setattr, sys, 'unraisablehook', old_hook)
+
+        cache = self._makeOne()
+        oid = self._numbered_oid(42)
+        o = cache[oid] = self._makePersist(oid=oid)
+        # Clear the dict, or at least part of it.
+        # This is coupled to ``cleanup_hook``
+        del cache.data._addr_to_oid
+        del cache[oid]
+
+        self.assertEqual(unraised, [])
+
 
 @skipIfNoCExtension
 class CPickleCacheTests(PickleCacheTestMixin, unittest.TestCase):
@@ -1180,6 +1219,30 @@ class CPickleCacheTests(PickleCacheTestMixin, unittest.TestCase):
         self.assertEqual(cache.total_estimated_size, 0)
         self.assertEqual(cache.cache_non_ghost_count, 0)
         self.assertEqual(len(cache), 0)
+
+
+class TestWeakValueDictionary(unittest.TestCase):
+
+    def _getTargetClass(self):
+        from persistent.picklecache import _WeakValueDictionary
+        return _WeakValueDictionary
+
+    def _makeOne(self):
+        return self._getTargetClass()()
+
+    @unittest.skipIf(PYPY, "PyPy doesn't have the cleanup_hook")
+    def test_cleanup_hook_gc(self):
+        # A more targeted test than ``test_interpreter_finalization_ffi_cleanup``
+        # See https://github.com/zopefoundation/persistent/issues/150
+        wvd = self._makeOne()
+
+        class cdata(object):
+            o = object()
+            pobj_id = id(o)
+        wvd['key'] = cdata.o
+
+        wvd.__dict__.clear()
+        wvd.cleanup_hook(cdata)
 
 
 def test_suite():


### PR DESCRIPTION
Only affects CPython when PURE_PYTHON=1.

Add tests for this. They're a bit dicey because this is a hard situation to get into, but they do test the symptoms.

Fixes #150