### PR TITLE
Make the Python PickleCache run a GC when it evicts weakly-referenced objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@
   ``PURE_PYTHON=1``) to not print unraisable ``AttributeErrors`` from
   ``_WeakValueDictionary`` during garbage collection. See `issue 150
   <https://github.com/zopefoundation/persistent/issues/150>`_.
+- Make the pure-Python implementation of the cache run a garbage
+  collection (``gc.collect()``) on ``full_sweep``, ``incrgc`` and
+  ``minimize`` *if* it detects that an object that was weakly
+  referenced has been ejected. This solves issues on PyPy with ZODB raising
+  ``ConnectionStateError`` when there are persistent
+  ``zope.interface`` utilities/adapters registered. This partly
+  reverts a change from release 4.2.3.
 
 4.6.4 (2020-03-26)
 ==================

--- a/persistent/tests/test_picklecache.py
+++ b/persistent/tests/test_picklecache.py
@@ -446,7 +446,7 @@ class PickleCacheTestMixin(object):
 
         # Make a persistent object, put it in the cache as saved
         class P(self._getRealPersistentClass()):
-            "A real persistent object that can be weak referenced"
+            """A real persistent object that can be weak referenced."""
 
         p = P()
         p._p_jar = jar


### PR DESCRIPTION
This fixes hard-to-debug ZODB ConnectionStateError cases with persistent zope.component registrations on PyPy.

I tried to come up with a test that would also fail on CPython using circular references, but did not succeed (because part of evicting objects is clearing their dict, breaking the reference cycle).

Fixes #149. Well, band-aids it anyway. I'd like to think of a better way (the assumption that weakrefs are cleared immediately is pretty baked-in to zope.interface, at least when used with ZODB).

Currently based on #161 to avoid conflicts; only the last commit is relevant.