### PR TITLE
Trigger GHA after deleting its caches.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.9.1 (unreleased)
 ==================
 
-- Update Python 3.11 support to 3.11.0-beta3.
+- Update Python 3.11 support to 3.11.0-rc1.
 
 - Disable unsafe math optimizations in C code.  See `pull request 176
   <https://github.com/zopefoundation/persistent/pull/176>`_.


### PR DESCRIPTION
The new test checking against the `-Ofast` problem was failing on `master`.

I cleaned the caches using

```
repo=persistent;gh api -H "Accept: application/vnd.github+json" /repos/zopefoundation/$repo/actions/caches|jq -r .actions_caches[].key|sort -u|grep Linux-pip-|xargs -I{} gh api -H "Accept: application/vnd.github+json" --method DELETE /repos/zopefoundation/$repo/actions/caches?key={}
```

Rerunning the failed jobs on `master` was not enough, so I am doing a complete re-run here.