### PR TITLE
Add preliminary support for Python 3.13a1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,7 +319,9 @@ jobs:
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
-          pip install -U 'cffi; platform_python_implementation == "CPython"'
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,6 +304,9 @@ jobs:
         if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
           # coverage has a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage
@@ -319,9 +322,7 @@ jobs:
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
+          pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
           pip install -U setuptools wheel twine
           # cffi will probably have no public release until a beta or even RC
           # version of Python 3.13.
-          pip install -U cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip
+          pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
 
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -107,13 +107,13 @@ jobs:
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -140,12 +140,11 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
           pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
           # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
           pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
-
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
@@ -211,7 +210,7 @@ jobs:
       - name: Upload persistent wheel (macOS x86_64)
         if: >
           startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*x86_64.whl
@@ -220,7 +219,7 @@ jobs:
           startsWith(runner.os, 'Mac')
           && !(startsWith(matrix.python-version, 'pypy')
                || matrix.python-version == '3.7')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # The arm64 wheel is uploaded with a different name just so it can be
           # manually downloaded when desired. The wheel itself *cannot* be tested
@@ -230,7 +229,7 @@ jobs:
       - name: Upload persistent wheel (all other platforms)
         if: >
           !startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*whl
@@ -256,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -267,13 +266,13 @@ jobs:
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -296,7 +295,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download persistent wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -366,9 +365,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -391,7 +390,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download persistent wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -417,9 +416,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -442,7 +441,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download persistent wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -470,9 +469,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -522,7 +521,7 @@ jobs:
           bash .manylinux.sh
 
       - name: Upload persistent wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*whl
           name: manylinux_${{ matrix.image }}_wheels.zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
           # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
           pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
           # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
-          pip install -U "twine @ https://github.com/pypa/twine/archive/refs/heads/main.zip"
+          pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
 
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -178,7 +179,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
+      - name: Install persistent and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre .[test]
       - name: Install persistent and dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -222,6 +231,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -241,6 +251,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -277,7 +288,22 @@ jobs:
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
+      - name: Install persistent 3.13.0-alpha - 3.13.0
+        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
+        run: |
+          pip install -U wheel setuptools
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/persistent-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre -U -e .[test]
       - name: Install persistent
+        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,8 +141,10 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine
           # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13.
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
           pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
+          # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
+          pip install -U "twine @ https://github.com/pypa/twine/archive/refs/heads/main.zip"
 
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13.
+          pip install -U cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip
+
       - name: Install Build Dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,6 +28,7 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
+        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -41,14 +42,20 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "a361e1fd"
+commit-id = "6f8d8c51"
 
 [python]
 with-appveyor = true

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "6f8d8c51"
+commit-id = "0160ca3b"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 5.2 (unreleased)
 ================
 
+- Add preliminary support for Python 3.13a1.
+
+
 5.1 (2023-10-05)
 ================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2 (unreleased)
 ================
 
-- Add preliminary support for Python 3.13a1.
+- Add preliminary support for Python 3.13a3.
 
 
 5.1 (2023-10-05)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
+    # `multibuild` cannot install non-final versions as they are not on
+    # ftp.python.org, so we skip Python 3.13 until its final release:
+    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ deps =
     check-manifest
     check-python-versions >= 0.20.0
     wheel
+commands_pre =
 commands =
     check-manifest
     check-python-versions

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,17 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
+    py313,py313-pure
     pypy3
     docs
     coverage
 
 [testenv]
 usedevelop = true
+pip_pre = py313: true
 deps =
     py37: urllib3 < 2
+    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0
@@ -46,17 +49,38 @@ commands =
     python -c 'import os, subprocess; subprocess.check_call("coverage run -a -m zope.testrunner --test-path=src", env=dict(os.environ, PURE_PYTHON="0"), shell=True)'
     coverage html -i
     coverage report -i -m --fail-under=99.8
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+basepython = python3
+skip_install = true
+deps =
+    twine
+    build
+    check-manifest
+    check-python-versions >= 0.20.0
+    wheel
+commands =
+    check-manifest
+    check-python-versions
+    python -m build --sdist --no-isolation
+    twine check dist/*
 
 [testenv:lint]
 basepython = python3
 skip_install = true
-commands =
-    check-manifest
-    check-python-versions
 deps =
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
+    isort
+commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
+
+[testenv:isort-apply]
+basepython = python3
+skip_install = true
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Depends on https://github.com/python-cffi/cffi/issues/23 ~~and its release in a version of `cffi` > 1.16.~~ we are now using an unreleased version with https://github.com/zopefoundation/meta/pull/227