### PR TITLE
refactor: convert 'setup()' metadata to TOML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,6 +157,8 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine
+          # Remove this hack once 'cffi' has a release supporting Python 3.13.
+          pip install -e "git+https://github.com/python-cffi/cffi.git#egg=cffi"
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,9 +103,10 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        os: [ubuntu-20.04, macos-11, windows-latest]
+          - "3.13.0-alpha - 3.13.0"
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-11
+          - os: macos-latest
             python-version: "pypy-3.10"
 
     steps:
@@ -151,10 +152,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine cffi
+          pip install -U setuptools wheel twine
+      - name: Install Build Dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
 
       - name: Build persistent (macOS x86_64, Python 3.8+)
         if: >
@@ -195,7 +202,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
+      - name: Install persistent and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre .[test]
       - name: Install persistent and dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -239,6 +254,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -258,9 +274,10 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        os: [ubuntu-20.04, macos-11, windows-latest]
+          - "3.13.0-alpha - 3.13.0"
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-11
+          - os: macos-latest
             python-version: "pypy-3.10"
 
     steps:
@@ -311,7 +328,22 @@ jobs:
         with:
           name: persistent-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
+      - name: Install persistent 3.13.0-alpha - 3.13.0 ${{ matrix.python-version }}
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U wheel setuptools
+          # coverage might have a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/persistent-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre -U -e .[test]
       - name: Install persistent
+        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
@@ -344,7 +376,7 @@ jobs:
 
   coveralls_finish:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: AndreMiras/coveralls-python-action@develop
@@ -357,7 +389,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: checkout
@@ -425,7 +457,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: checkout
@@ -489,7 +521,7 @@ jobs:
           # python -m pylint --limit-inference-results=1 --rcfile=.pylintrc persistent -f parseable -r n
 
   manylinux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,6 +28,7 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
+        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -41,14 +42,20 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "905c2a64"
+commit-id = "3a81d045"
 
 [python]
 with-appveyor = true
 with-windows = true
 with-pypy = true
-with-future-python = false
+with-future-python = true
 with-docs = true
 with-sphinx-doctests = true
 with-macos = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "cffi ; platform_python_implementation == 'CPython'",
+    "cffi @ git+https://github.com/python-cffi/cffi.git ; platform_python_implementation == 'CPython' and python_version >= '3.13a0'",
+]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "persistent"
+version = "5.3.dev0"
+dynamic = ["readme"]
+authors = [
+    {name = "Zope Foundation and Contributors", email = "zodb-dev@zope.org"},
+]
+description = "Translucent persistent objects"
+requires-python = ">=3.7"
+license = {text = "ZPL 2.1"}
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "License :: OSI Approved :: Zope Public License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Framework :: ZODB",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: Unix",
+]
+dependencies = [
+    "zope.deferredimport",
+    "zope.interface",
+    "cffi ; platform_python_implementation == 'CPython'",
+    "cffi @ git+https://github.com/python-cffi/cffi.git ; platform_python_implementation == 'CPython' and python_version >= '3.13a0'",
+]
+
+[project.urls]
+documentation = "https://persistent.readthedocs.io"
+repository = "https://github.com/zopefoundation/persistent/"
+issue_tracker = "https://github.com/zopefoundation/persistent/issues"
+changelog = "https://github.com/zopefoundation/persistent/blob/master/CHANGES.rst"
+
+[project.optional-dependencies]
+test = [
+    "zope.testrunner",
+    "manuel",
+]
+testing = []   # backward-compatibility
+docs = [
+    "Sphinx",
+    "repoze.sphinx.autointerface",
+    "sphinx_rtd_theme",
+]
+
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.rst", "CHANGES.rst"]}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["persistent"]

--- a/setup.py
+++ b/setup.py
@@ -12,25 +12,10 @@
 #
 ##############################################################################
 
-import os
 import platform
 
 from setuptools import Extension
-from setuptools import find_packages
 from setuptools import setup
-
-
-version = '5.3.dev0'
-
-here = os.path.abspath(os.path.dirname(__file__))
-
-
-def _read_file(filename):
-    with open(os.path.join(here, filename)) as f:
-        return f.read()
-
-
-README = (_read_file('README.rst') + '\n\n' + _read_file('CHANGES.rst'))
 
 
 define_macros = (
@@ -86,64 +71,8 @@ else:
         'src/persistent/ring.h',
     ]
 
-setup(name='persistent',
-      version=version,
-      description='Translucent persistent objects',
-      long_description=README,
-      classifiers=[
-          "Development Status :: 6 - Mature",
-          "License :: OSI Approved :: Zope Public License",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8",
-          "Programming Language :: Python :: 3.9",
-          "Programming Language :: Python :: 3.10",
-          "Programming Language :: Python :: 3.11",
-          "Programming Language :: Python :: 3.12",
-          "Programming Language :: Python :: Implementation :: CPython",
-          "Programming Language :: Python :: Implementation :: PyPy",
-          "Framework :: ZODB",
-          "Topic :: Database",
-          "Topic :: Software Development :: Libraries :: Python Modules",
-          "Operating System :: Microsoft :: Windows",
-          "Operating System :: Unix",
-      ],
-      author="Zope Foundation and Contributors",
-      author_email="zodb-dev@zope.org",
-      url="https://github.com/zopefoundation/persistent/",
-      project_urls={
-        'Documentation': 'https://persistent.readthedocs.io',
-        'Issue Tracker': 'https://github.com/zopefoundation/persistent/issues',
-        'Sources': 'https://github.com/zopefoundation/persistent',
-      },
-      license="ZPL 2.1",
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      include_package_data=True,
-      zip_safe=False,
+setup(
       ext_modules=ext_modules,
       cffi_modules=['src/persistent/_ring_build.py:ffi'],
       headers=headers,
-      extras_require={
-          'test': [
-              'zope.testrunner',
-              'manuel',
-          ],
-          'testing': (),
-          'docs': [
-              'Sphinx',
-              'repoze.sphinx.autointerface',
-              'sphinx_rtd_theme',
-          ],
-      },
-      python_requires='>=3.7',
-      install_requires=[
-          'zope.deferredimport',
-          'zope.interface',
-          "cffi ; platform_python_implementation == 'CPython'",
-      ],
-      setup_requires=[
-          "cffi ; platform_python_implementation == 'CPython'",
-      ],
-      entry_points={})
+)

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
+    py313,py313-pure
     pypy3
     docs
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = py313: true
 deps =
     py37: urllib3 < 2
+    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0


### PR DESCRIPTION
Depend on GH master branch of 'cffi' for CPython 3.13*, until there is a release of 'cffi' which supports it.