### PR TITLE
Require cffi from meta/config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,9 +104,9 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13.0-alpha - 3.13.0"
-        os: [ubuntu-20.04, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-11
+          - os: macos-latest
             python-version: "pypy-3.10"
 
     steps:
@@ -278,9 +278,9 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13.0-alpha - 3.13.0"
-        os: [ubuntu-20.04, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-11
+          - os: macos-latest
             python-version: "pypy-3.10"
 
     steps:
@@ -381,7 +381,7 @@ jobs:
 
   coveralls_finish:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: AndreMiras/coveralls-python-action@develop
@@ -394,7 +394,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: checkout
@@ -462,7 +462,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: checkout
@@ -526,7 +526,7 @@ jobs:
           # python -m pylint --limit-inference-results=1 --rcfile=.pylintrc persistent -f parseable -r n
 
   manylinux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,9 +104,9 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13.0-alpha - 3.13.0"
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-latest]
         exclude:
-          - os: macos-latest
+          - os: macos-11
             python-version: "pypy-3.10"
 
     steps:
@@ -163,7 +163,8 @@ jobs:
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine cffi
+          pip install -U setuptools wheel twine
+          pip install cffi
 
       - name: Build persistent (macOS x86_64, Python 3.8+)
         if: >
@@ -277,9 +278,9 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13.0-alpha - 3.13.0"
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-latest]
         exclude:
-          - os: macos-latest
+          - os: macos-11
             python-version: "pypy-3.10"
 
     steps:
@@ -380,7 +381,7 @@ jobs:
 
   coveralls_finish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Coveralls Finished
       uses: AndreMiras/coveralls-python-action@develop
@@ -393,7 +394,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     steps:
       - name: checkout
@@ -461,7 +462,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     steps:
       - name: checkout
@@ -525,7 +526,7 @@ jobs:
           # python -m pylint --limit-inference-results=1 --rcfile=.pylintrc persistent -f parseable -r n
 
   manylinux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "e6285cce"
+commit-id = "612c13eb"
 
 [python]
 with-appveyor = true
@@ -46,17 +46,5 @@ additional-ignores = [
     "docs/_build/html/_sources/api/*",
     ]
 
-[appveyor]
-global-env-vars = [
-    "# Currently the builds use @mgedmin's Appveyor account.  The PyPI token belongs",
-    "# to zope.wheelbuilder, which is managed by @mgedmin and @dataflake.",
-    "",
-    "global:",
-    "  TWINE_USERNAME: __token__",
-    "  TWINE_PASSWORD:",
-    "    secure: aoZC/+rvJKg8B5GMGIxd1WN5nlr8JpHkzvR9PeQFNDJjz6AQ4dSfbdAxcUzjgusof0wqc7W2m4XhdWQdXVPQ8D62xeizEEG/ONwTczHdE6dfl87VZ23egxbGmsQtcf/Rxa1jvEsHAFAYFMGndArmZ3slMSeQCwEfc/blpNlVi7VcLYcCbKqh9q41DPhIuq3HcLypdocMu9aooDzwqia69n1e7ZkFpBnQu53YxZhuFQmzoY2pBJAM3uI4+6yrH3wUw9QF0ySzrgpgN9oLE2RVUg==",
-    ]
-install-steps = [
-    "- pip install cffi",
-    "- pip install -U -e .[test]",
-    ]
+[c-code]
+require-cffi = true

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "612c13eb"
+commit-id = "133f57d5"
 
 [python]
 with-appveyor = true


### PR DESCRIPTION
Created via https://github.com/zopefoundation/meta/pull/236.

The changes of the os versions are because this is not yet on master. This PR is mostly to show that https://github.com/zopefoundation/meta/pull/236 does not delete the cffi installation.