### PR TITLE
tests: drop extra run of tests for coverage

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -17,7 +17,6 @@ with-macos = false
 use-flake8 = true
 coverage-command = [
     "coverage run -m zope.testrunner --test-path=src {posargs:-vc}",
-    "python -c 'import os, subprocess; subprocess.check_call(\"coverage run -a -m zope.testrunner --test-path=src\", env=dict(os.environ, PURE_PYTHON=\"1\"), shell=True)'",
     "python -c 'import os, subprocess; subprocess.check_call(\"coverage run -a -m zope.testrunner --test-path=src\", env=dict(os.environ, PURE_PYTHON=\"0\"), shell=True)'",
     ]
 testenv-deps = [

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ setenv =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
-    python -c 'import os, subprocess; subprocess.check_call("coverage run -a -m zope.testrunner --test-path=src", env=dict(os.environ, PURE_PYTHON="1"), shell=True)'
     python -c 'import os, subprocess; subprocess.check_call("coverage run -a -m zope.testrunner --test-path=src", env=dict(os.environ, PURE_PYTHON="0"), shell=True)'
     coverage html -i
     coverage report -i -m --fail-under=99.8


### PR DESCRIPTION
The 'PURE_PYTHON=1' case is handled by the main command.