### PR TITLE
Use Py_REFCNT to access cPersistentObject refcounts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,16 @@
 6.2 (unreleased)
 ================
 
+- Use ``Py_REFCNT`` to access ``cPersistentObject`` reference counts in
+  assertions.
+
 
 6.1 (2024-09-17)
 ================
 
 - Add final support for Python 3.13.
 
-- Removed ``persisent.cPersistence.simple_new`` fossil.
+- Removed ``persistent.cPersistence.simple_new`` fossil.
   See https://github.com/zopefoundation/persistent/pull/208
 
 

--- a/src/persistent/cPickleCache.c
+++ b/src/persistent/cPickleCache.c
@@ -623,7 +623,7 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
 
     dead_pers_obj = (cPersistentObject*)PyDict_GetItem(self->data, oid);
     assert(dead_pers_obj);
-    assert(dead_pers_obj->ob_refcnt == 0);
+    assert(Py_REFCNT(dead_pers_obj) == 0);
 
     dead_pers_obj_ref_to_self = (ccobject*)dead_pers_obj->cache;
     assert(dead_pers_obj_ref_to_self == self);
@@ -633,7 +633,7 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
     */
 
     Py_INCREF(dead_pers_obj);
-    assert(dead_pers_obj->ob_refcnt == 1);
+    assert(Py_REFCNT(dead_pers_obj) == 1);
     /* Incremement the refcount again, because delitem is going to
         DECREF it.  If its refcount reached zero again, we'd call back to
         the dealloc function that called us.
@@ -662,7 +662,7 @@ cc_oid_unreferenced(ccobject *self, PyObject *oid)
     Py_DECREF(dead_pers_obj_ref_to_self);
     dead_pers_obj->cache = NULL;
 
-    assert(dead_pers_obj->ob_refcnt == 1);
+    assert(Py_REFCNT(dead_pers_obj) == 1);
 
     /* Don't DECREF the object, because this function is called from
         the object's dealloc function. If the refcnt reaches zero (again), it


### PR DESCRIPTION
These assertions failed to compile if built without `-DNDEBUG`.  As of setuptools 75.7.0, setting `CFLAGS` to anything while building an extension no longer copies the `CFLAGS` that Python itself was built with, so `NDEBUG` is less likely to be defined.  See https://github.com/pypa/setuptools/issues/4836 and https://bugs.debian.org/1098602.