### PR TITLE
Clean up dependency installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U "setuptools <= 75.6.0" wheel twine
-          pip install cffi
 
       - name: Build persistent (macOS x86_64)
         if: >
@@ -486,7 +485,6 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U tox
-          pip install -U 'cffi; platform_python_implementation == "CPython"'
           pip install -U  "`ls dist/persistent-*.whl`[docs]"
       - name: Run release check
         env:

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "36100db0"
+commit-id = "3c1c588c"
 
 [python]
 with-windows = true
@@ -41,6 +41,3 @@ additional-rules = [
 additional-ignores = [
     "docs/_build/html/_sources/api/*",
     ]
-
-[c-code]
-require-cffi = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.2 (unreleased)
 ================
 
+- Move package build requirements from ``setup.py`` to ``pyproject.toml``.
+
 - Drop support for Python 3.8.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [build-system]
-requires = ["setuptools <= 75.6.0"]
+requires = ["setuptools <= 75.6.0", "cffi; platform_python_implementation == 'CPython'"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
+# 
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
+
 [build-system]
 requires = ["setuptools <= 75.6.0", "cffi; platform_python_implementation == 'CPython'"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,4 @@ setup(name='persistent',
           'zope.interface',
           "cffi ; platform_python_implementation == 'CPython'",
       ],
-      setup_requires=[
-          "cffi ; platform_python_implementation == 'CPython'",
-      ],
       entry_points={})

--- a/tox.ini
+++ b/tox.ini
@@ -53,12 +53,12 @@ basepython = python3
 skip_install = true
 deps =
     setuptools <= 75.6.0
+    cffi; platform_python_implementation == 'CPython'
     twine
     build
     check-manifest
     check-python-versions >= 0.20.0
     wheel
-    cffi; platform_python_implementation == "CPython"
 commands_pre =
 commands =
     check-manifest


### PR DESCRIPTION
Looks like persistent was the last package using `setup_requires` in `setup.py`. Following https://github.com/zopefoundation/meta/issues/16 I have moved it into `pyproject.toml` instead.

During testing I discovered that the explicit dependency installation of `cffi` is no longer required, except for the `tox` step `release-check`, which executes `python -m build --sdist --no-isolation` and will fail if `cffi` has not been installed in advance. So this package can get rid of the meta configuration `require-cffi`.

In a forthcoming PR for zope.meta I want to get rid of `require-cffi`, which always felt like a crutch, and use the build requirements spelled out in the package's own `pyproject.toml` instead to pre-install requirements where it is still necessary. I am already using that code here to generate part of the requirements inside that `tox` configuration for `release-check`, that's why the cffi requirement has moved up in the file.