### PR TITLE
Fix cffi extension build configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 6.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix setuptools configuration to build missing cffi extension module.
+  The released wheels for version 6.2 will not work, they are missing
+  a compiled extension module.
+  (`#222 <https://github.com/zopefoundation/persistent/issues/222>`_)
 
 
 6.2 (2025-10-02)

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,10 @@ setup(name='persistent',
       ext_modules=ext_modules,
       cffi_modules=['src/persistent/_ring_build.py:ffi'],
       headers=headers,
+      setup_requires=[
+          "cffi ; platform_python_implementation == 'CPython'",
+          "pycparser",
+      ],
       extras_require={
           'test': [
               'zope.testrunner',


### PR DESCRIPTION
Closes #222

CFFI does not support pyproject.toml yet, instructions and prerequisites for building CFFI extension modules must stay in setup.py for now.