### PR TITLE
Pre-install cffi to fix macOS Python 3.15 build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
         if: matrix.python-version == '3.15'
         run: |
           pip install -U pip
-          pip install -U "setuptools >= 78.1.1,< 82" wheel twine
+          pip install -U "setuptools >= 78.1.1,< 82" wheel twine cffi pycparser
       - name: Install Build Dependencies
         if: matrix.python-version != '3.15'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -388,7 +388,7 @@ jobs:
       - name: Submit to Coveralls
         # This is a container action, which only runs on Linux.
         if: ${{ startsWith(runner.os, 'Linux') }}
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           parallel: true
 
@@ -397,7 +397,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
+      uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
 


### PR DESCRIPTION
Fix the failing `build-package (3.15, macos-latest)` job.

**Pre-install cffi natively for Python 3.15 macOS builds**

On ARM64 macOS runners, the x86_64 cross-compilation step causes `setup_requires`/`fetch_build_eggs` to build cffi from source with x86_64 flags (no pre-built 3.15 wheel exists yet). Python (arm64) then cannot load the x86_64 `_cffi_backend.so`.

Pre-installing cffi via pip ensures it is available natively so setuptools does not attempt to rebuild it with cross-compilation flags.

**Replace coveralls action**

Replace `AndreMiras/coveralls-python-action@develop` with the official `coverallsapp/github-action@v2` (verified in the GitHub Marketplace), as the org policy disallows the former.