### PR TITLE
Bump timeout in test_rapid_create_destroy_cycle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Change log
   values from test methods in ``test_picklecache.py``.
   (`#235 <https://github.com/zopefoundation/persistent/issues/235>`_)
 
+- Bump timeout in ``test_rapid_create_destroy_cycle`` to allow more headroom
+  on slow architectures.
+
 
 6.7 (2026-05-26)
 ----------------

--- a/src/persistent/tests/test_threading.py
+++ b/src/persistent/tests/test_threading.py
@@ -279,7 +279,7 @@ class ConcurrentCacheTests(TestCase):
         for t in threads:
             t.start()
         for t in threads:
-            t.join(timeout=30)
+            t.join(timeout=60)
             self.assertFalse(t.is_alive(), "Thread hung")
         self.assertEqual(errors, [], f"Errors in threads: {errors}")
 


### PR DESCRIPTION
Even on my fast x86 laptop, this takes about 6 seconds, so it's not unreasonable that it might take more than 30 seconds on slower architectures.  Debian's riscv64 porter box takes around 35 seconds to run this test.  Give it a bit more headroom.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] I included a change log entry in my commits.